### PR TITLE
install: Expose test + docs requirements, encourage use of virtualenv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,15 +83,12 @@ jobs:
       - name: Setup castxml config
         if: matrix.compiler == 'gcc' && matrix.version == '7'
         run: mv unittests/configs/gcc7.cfg unittests/xml_generator.cfg;
-      - name: Setup Python test libs
+      - name: Install Python lib and test libs
         run: |
-          pip install coveralls
-          pip install coverage
-          pip install pycodestyle
+          pip install .[test]
       - name: Run tests
         run: |
           export PATH=~/castxml/bin:$PATH
-          python setup.py install
           coverage run -m unittests.test_all
           coverage combine
       - name: Upload coverage to Codecov

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/examples/caching/example.hpp.xml
 test_cost.log
 docs/apidocs
 htmlcov
+/venv/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import subprocess
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('.') + "/../")
 
-from ..release_utils import utils  # nopep8
+from release_utils import utils  # nopep8
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -7,15 +7,17 @@ Building the documentation locally
 You can build the documentation yourself. In order for this to work you need
 sphinx doc (http://sphinx-doc.org) and the readthedocs theme:
 
-    pip install sphinx
+.. code-block:: shell
 
-    pip install sphinx_rtd_theme
+  pip install .[docs]
 
 Then just run the following command in the root folder:
 
+.. code-block:: shell
+
   make html
 
-This will build the documentation locally in the `docs/_build/html` folder.
+This will build the documentation locally in the ``docs/_build/html`` folder.
 
 For each commit on the master and develop branches, the documentation is
 automatically built and can be found here: https://readthedocs.org/projects/pygccxml/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -18,11 +18,27 @@ Installation of pygccxml
 
 You can use pip to install pygccxml:
 
-  pip install pygccxml
+.. code-block:: shell
+
+    pip install pygccxml
 
 To install from source, you can use the usual procedure:
 
+.. code-block:: shell
+
   python setup.py install
+
+For development
+%%%%%%%%%%%%%%%
+
+You should use a ``virtualenv`` when possible. Example recipe:
+
+.. code-block:: shell
+
+  cd pygccxml  # git root
+  python -m virtualenv ./venv
+  source ./venv/bin/activate
+  pip install --editable .[test]
 
 GCC-XML (Legacy)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,16 @@ from release_utils import utils
 
 version = utils.find_version("../pygccxml/__init__.py")
 
+requirements_test = {
+  "coverage",
+  "coveralls",
+  "pycodestyle",
+}
+requirements_docs = {
+  "sphinx",
+  "sphinx_rtd_theme",
+}
+
 setup(name="pygccxml",
       version=version,
       author="Roman Yakovenko",
@@ -25,6 +35,10 @@ setup(name="pygccxml",
                 "pygccxml.declarations",
                 "pygccxml.parser",
                 "pygccxml.utils"],
+      extras_require={
+          "test": list(requirements_test),
+          "docs": list(requirements_docs),
+      },
       classifiers=[
           "Development Status :: 5 - Production/Stable",
           "Environment :: Console",

--- a/unittests/pep8_tester.py
+++ b/unittests/pep8_tester.py
@@ -4,9 +4,10 @@
 # See http://www.boost.org/LICENSE_1_0.txt
 
 import os
-import pycodestyle
 import unittest
 import fnmatch
+
+import pycodestyle
 
 
 class Test(unittest.TestCase):


### PR DESCRIPTION
- Use `setuputils.setup(..., extras_require)`
- Organize imports according to PEP8 (builtin, 3rd party, then 1st party)

For `extras_require`:
https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
Saw this when looking at `trimesh`: https://github.com/mikedh/trimesh/blob/4cacbffcd9bd1a637bf05b638bc3376464e3577b/setup.py

For PEP8 imports:
https://www.python.org/dev/peps/pep-0008/#imports