### PR TITLE
Warn if "include directories" do not exist

### DIFF
--- a/pygccxml/parser/config.py
+++ b/pygccxml/parser/config.py
@@ -204,7 +204,7 @@ class parser_configuration_t(object):
             msg = '%s("%s") does not exist.' % (meaning, dir_path)
             if meaning == 'include directory':
                 # Warn instead of failing.
-                warnings.warn(msg)
+                warnings.warn(msg, RuntimeWarning)
             else:
                 raise RuntimeError(msg)
         else:

--- a/pygccxml/parser/config.py
+++ b/pygccxml/parser/config.py
@@ -12,6 +12,7 @@ import os
 import copy
 import platform
 import subprocess
+import warnings
 # In py3, ConfigParser was renamed to the more-standard configparser.
 # But there's a py3 backport that installs "configparser" in py2, and I don't
 # want it because it has annoying deprecation warnings. So try the real py2
@@ -200,10 +201,10 @@ class parser_configuration_t(object):
         if os.path.isdir(dir_path):
             return
         if os.path.exists(self.working_directory):
-            msg = '%s("%s") does not exist!' % (meaning, dir_path)
+            msg = '%s("%s") does not exist.' % (meaning, dir_path)
             if meaning == 'include directory':
                 # Warn instead of failing.
-                print(msg)
+                warnings.warn(msg)
             else:
                 raise RuntimeError(msg)
         else:

--- a/pygccxml/parser/config.py
+++ b/pygccxml/parser/config.py
@@ -201,7 +201,7 @@ class parser_configuration_t(object):
             return
         if os.path.exists(self.working_directory):
             msg = '%s("%s") does not exist!' % (meaning, dir_path)
-            if meaning == 'include_directory':
+            if meaning == 'include directory':
                 # Warn instead of failing.
                 print(msg)
             else:

--- a/pygccxml/parser/config.py
+++ b/pygccxml/parser/config.py
@@ -200,8 +200,12 @@ class parser_configuration_t(object):
         if os.path.isdir(dir_path):
             return
         if os.path.exists(self.working_directory):
-            raise RuntimeError(
-                '%s("%s") does not exist!' % (meaning, dir_path))
+            msg = '%s("%s") does not exist!' % (meaning, dir_path)
+            if meaning == 'include_directory':
+                # Warn instead of failing.
+                print(msg)
+            else:
+                raise RuntimeError(msg)
         else:
             raise RuntimeError(
                 '%s("%s") should be "directory", not a file.' %

--- a/unittests/test_all.py
+++ b/unittests/test_all.py
@@ -84,6 +84,7 @@ from . import test_find_noncopyable_vars
 from . import test_hash
 from . import test_null_comparison
 from . import test_comments
+from . import test_warn_missing_include_dirs
 
 testers = [
     pep8_tester,
@@ -159,6 +160,7 @@ testers = [
     test_hash,
     test_null_comparison,
     test_comments,
+    test_warn_missing_include_dirs,
 ]
 
 if platform.system() != 'Windows':

--- a/unittests/test_warn_missing_include_dirs.py
+++ b/unittests/test_warn_missing_include_dirs.py
@@ -3,11 +3,11 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See http://www.boost.org/LICENSE_1_0.txt
 
-from contextlib import redirect_stdout
 import io
 import sys
 import os
 import unittest
+import warnings
 
 sys.path.insert(1, os.path.join(os.curdir, '..'))
 sys.path.insert(1, "../pygccxml")
@@ -36,12 +36,13 @@ class Test(unittest.TestCase):
             xml_generator_path=generator_path,
             xml_generator=name,
             include_paths=["doesnt/exist", os.getcwd()])
-        with redirect_stdout(f):
+        with warnings.catch_warnings(record=True) as f:
             parser.parse_string(code, config)
 
         self.assertIn(
-            "include directory(\"doesnt/exist\") does not exist!",
-            f.getvalue())
+            "include directory(\"doesnt/exist\") does not exist",
+            str(f[0].message))
+
 
 
 def create_suite():

--- a/unittests/test_warn_missing_include_dirs.py
+++ b/unittests/test_warn_missing_include_dirs.py
@@ -1,0 +1,58 @@
+# Copyright 2014-2017 Insight Software Consortium.
+# Copyright 2004-2009 Roman Yakovenko.
+# Distributed under the Boost Software License, Version 1.0.
+# See http://www.boost.org/LICENSE_1_0.txt
+
+from contextlib import redirect_stdout
+import io
+import sys
+import os
+import unittest
+
+sys.path.insert(1, os.path.join(os.curdir, '..'))
+sys.path.insert(1, "../pygccxml")
+
+from pygccxml import parser  # nopep8
+from pygccxml import utils  # nopep8
+
+
+class Test(unittest.TestCase):
+
+    def test_config(self):
+        """
+            Test that a missing include directory is printing a warning,
+            not raising an error
+        """
+
+        # Some code to parse for the example
+        code = "int a;"
+
+        # Find the location of the xml generator (castxml or gccxml)
+        generator_path, name = utils.find_xml_generator()
+
+        f = io.StringIO()
+        # Path given as include director doesn't exist
+        config = parser.xml_generator_configuration_t(
+            xml_generator_path=generator_path,
+            xml_generator=name,
+            include_paths=["doesnt/exist", os.getcwd()])
+        with redirect_stdout(f):
+            parser.parse_string(code, config)
+
+        self.assertIn(
+            "include directory(\"doesnt/exist\") does not exist!",
+            f.getvalue())
+
+
+def create_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(Test))
+    return suite
+
+
+def run_suite():
+    unittest.TextTestRunner(verbosity=2).run(create_suite())
+
+
+if __name__ == "__main__":
+    run_suite()

--- a/unittests/test_warn_missing_include_dirs.py
+++ b/unittests/test_warn_missing_include_dirs.py
@@ -35,8 +35,7 @@ class Test(unittest.TestCase):
             xml_generator_path=generator_path,
             xml_generator=name,
             include_paths=["doesnt/exist", os.getcwd()])
-        self.assertWarns(UserWarning, parser.parse_string, code, config)
-
+        self.assertWarns(RuntimeWarning, parser.parse_string, code, config)
 
 
 def create_suite():

--- a/unittests/test_warn_missing_include_dirs.py
+++ b/unittests/test_warn_missing_include_dirs.py
@@ -30,18 +30,12 @@ class Test(unittest.TestCase):
         # Find the location of the xml generator (castxml or gccxml)
         generator_path, name = utils.find_xml_generator()
 
-        f = io.StringIO()
         # Path given as include director doesn't exist
         config = parser.xml_generator_configuration_t(
             xml_generator_path=generator_path,
             xml_generator=name,
             include_paths=["doesnt/exist", os.getcwd()])
-        with warnings.catch_warnings(record=True) as f:
-            parser.parse_string(code, config)
-
-        self.assertIn(
-            "include directory(\"doesnt/exist\") does not exist",
-            str(f[0].message))
+        self.assertWarns(UserWarning, parser.parse_string, code, config)
 
 
 


### PR DESCRIPTION
Instead of raising a RunTime error on a missing include
directory, print a warning to the screen and allow processing to continue.