### PR TITLE
Switch to xml for coverage reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,11 +91,12 @@ jobs:
           export PATH=~/castxml/bin:$PATH
           coverage run -m unittests.test_all
           coverage combine
+          coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: .coverage
+          file: coverage.xml
           flags: unittests
           env_vars: OS,PYTHON
           name: codecov-umbrella


### PR DESCRIPTION
This branch provides a fix for the `codecov` failures. The previously generated `.coverage` file generated by running the `coverage` tool was in an invalid format for Github's `codecov`. This branch switches the format over to `xml`, which can be processed by `codecov`