### PR TITLE
Use "overrides" information from CastXML

### DIFF
--- a/pygccxml/declarations/calldef.py
+++ b/pygccxml/declarations/calldef.py
@@ -246,7 +246,7 @@ class calldef_t(declaration.declaration_t):
     @property
     def overrides(self):
         """If a function is marked as an overrides, contains
-        the declaration which this function overridess."""
+        the declaration which this function overrides."""
         return self._overrides
 
     @overrides.setter

--- a/pygccxml/declarations/calldef.py
+++ b/pygccxml/declarations/calldef.py
@@ -165,6 +165,7 @@ class calldef_t(declaration.declaration_t):
         self._calling_convention = None
         self._has_inline = None
         self._mangled = mangled
+        self._overrides = None
 
     def _get__cmp__call_items(self):
         """
@@ -241,6 +242,16 @@ class calldef_t(declaration.declaration_t):
         """list of all optional arguments, the arguments that have default
         value"""
         return self.arguments[len(self.required_args):]
+
+    @property
+    def overrides(self):
+        """If a function is marked as an overrides, contains
+        the declaration which this function overridess."""
+        return self._overrides
+
+    @overrides.setter
+    def overrides(self, overrides):
+        self._overrides = overrides
 
     @property
     def does_throw(self):

--- a/pygccxml/parser/scanner.py
+++ b/pygccxml/parser/scanner.py
@@ -47,6 +47,7 @@ XML_AN_MEMBERS = "members"
 XML_AN_MUTABLE = "mutable"
 XML_AN_NAME = "name"
 XML_AN_OFFSET = "offset"
+XML_AN_OVERRIDES = "overrides"
 XML_AN_PURE_VIRTUAL = "pure_virtual"
 XML_AN_RESTRICT = "restrict"
 XML_AN_RETURNS = "returns"
@@ -247,6 +248,9 @@ class scanner_t(xml.sax.handler.ContentHandler):
         for gccxml_id, decl in self.__declarations.items():
             if not isinstance(decl.comment, declarations.comment.comment_t):
                 decl.comment = self._handle_comment(decl)
+            if isinstance(decl, declarations.calldef_t) and decl.overrides:
+                overrides_decl = self.__declarations.get(decl.overrides)
+                decl.overrides = overrides_decl
 
     def declarations(self):
         return self.__declarations
@@ -581,6 +585,8 @@ class scanner_t(xml.sax.handler.ContentHandler):
                 calldef.virtuality = declarations.VIRTUALITY_TYPES.VIRTUAL
             else:
                 calldef.virtuality = declarations.VIRTUALITY_TYPES.NOT_VIRTUAL
+            if XML_AN_OVERRIDES in attrs:
+                calldef.overrides = attrs.get(XML_AN_OVERRIDES)
         else:
             calldef.class_inst = attrs[XML_AN_BASE_TYPE]
 

--- a/unittests/data/test_overrides.hpp
+++ b/unittests/data/test_overrides.hpp
@@ -1,0 +1,26 @@
+#ifndef simple_h
+#define simple_h
+
+#include <iostream>
+class base
+{
+public:
+  base() {};
+  ~base() {};
+  virtual int goodbye(int num_ref, int num_times) = 0;
+};
+
+class simple : public base
+{
+public:
+  simple() {};
+  ~simple() {};
+  int hello() { return 0; };
+  int goodbye(int , int) override
+    {
+      std::cout << "goodbye\n";
+      return 10;
+    } ;
+};
+
+#endif

--- a/unittests/data/test_overrides.hpp
+++ b/unittests/data/test_overrides.hpp
@@ -1,3 +1,6 @@
+// Copyright 2020 Insight Software Consortium.
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
 #ifndef simple_h
 #define simple_h
 

--- a/unittests/test_all.py
+++ b/unittests/test_all.py
@@ -84,6 +84,7 @@ from . import test_find_noncopyable_vars
 from . import test_hash
 from . import test_null_comparison
 from . import test_comments
+from . import test_overrides
 
 testers = [
     pep8_tester,
@@ -159,6 +160,7 @@ testers = [
     test_hash,
     test_null_comparison,
     test_comments,
+    test_overrides,
 ]
 
 if platform.system() != 'Windows':

--- a/unittests/test_overrides.py
+++ b/unittests/test_overrides.py
@@ -1,0 +1,61 @@
+# Copyright 2014-2020 Insight Software Consortium.
+# Copyright 2004-2009 Roman Yakovenko.
+# Distributed under the Boost Software License, Version 1.0.
+# See http://www.boost.org/LICENSE_1_0.txt
+
+import unittest
+
+from . import parser_test_case
+
+from pygccxml import parser
+from pygccxml import declarations
+
+
+class Test(parser_test_case.parser_test_case_t):
+    global_ns = None
+
+    def __init__(self, *args):
+        parser_test_case.parser_test_case_t.__init__(self, *args)
+        self.header = "test_overrides.hpp"
+        self.global_ns = None
+        self.config.castxml_epic_version = 1
+
+    def setUp(self):
+
+        if not self.global_ns:
+            decls = parser.parse([self.header], self.config)
+            Test.global_ns = declarations.get_global_namespace(decls)
+            Test.xml_generator_from_xml_file = \
+                self.config.xml_generator_from_xml_file
+        self.xml_generator_from_xml_file = Test.xml_generator_from_xml_file
+
+        self.global_ns = Test.global_ns
+
+    def test(self):
+        """
+        Check that the override information is populated for the
+        simple::goodbye function.  It should contain the decl for the
+        base::goodbye function.  Base::goodbye has no override so it
+        will be none
+        """
+        base = self.global_ns.class_("base").member_function("goodbye")
+        override_decl = self.global_ns.class_("simple")\
+                            .member_function("goodbye")
+
+        self.assertTrue(base.overrides is None)
+        self.assertFalse(override_decl.overrides is None)
+        self.assertEqual(override_decl.overrides, base)
+
+
+def create_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(Test))
+    return suite
+
+
+def run_suite():
+    unittest.TextTestRunner(verbosity=2).run(create_suite())
+
+
+if __name__ == "__main__":
+    run_suite()


### PR DESCRIPTION
Use the attr information called "overrides" to pass the declaration of
the function which is overridden by a declaration.