### PR TITLE
Handle default flags

### DIFF
--- a/pygccxml/parser/config.py
+++ b/pygccxml/parser/config.py
@@ -49,6 +49,7 @@ class parser_configuration_t(object):
             define_symbols=None,
             undefine_symbols=None,
             cflags="",
+            ccflags="",
             compiler=None,
             xml_generator=None,
             keep_xml=False,
@@ -72,6 +73,8 @@ class parser_configuration_t(object):
         self.__undefine_symbols = undefine_symbols
 
         self.__cflags = cflags
+
+        self.__ccflags = ccflags
 
         self.__compiler = compiler
 
@@ -197,6 +200,26 @@ class parser_configuration_t(object):
     def append_cflags(self, val):
         self.__cflags = self.__cflags + ' ' + val
 
+    @property
+    def ccflags(self):
+        """
+        additional cross-compatible flags to pass directly
+        to internal simulated compiler.
+        Castxml removes any definitions of its
+        pre-defined macros (e.g. -fopenmp). To propagate these down to the
+        compiler, these flags must also be passed here.
+        See `cc-opt` on castxml's documentation page:
+        https://github.com/CastXML/CastXML/blob/master/doc/manual/castxml.1.rst
+        """
+        return self.__ccflags
+
+    @ccflags.setter
+    def ccflags(self, val):
+        self.__ccflags = val
+
+    def append_ccflags(self, val):
+        self.__ccflags = self.__ccflags + ' ' + val
+
     def __ensure_dir_exists(self, dir_path, meaning):
         if os.path.isdir(dir_path):
             return
@@ -245,6 +268,7 @@ class xml_generator_configuration_t(parser_configuration_t):
             start_with_declarations=None,
             ignore_gccxml_output=False,
             cflags="",
+            ccflags="",
             compiler=None,
             xml_generator=None,
             keep_xml=False,
@@ -258,7 +282,7 @@ class xml_generator_configuration_t(parser_configuration_t):
             include_paths=include_paths,
             define_symbols=define_symbols,
             undefine_symbols=undefine_symbols,
-            cflags=cflags,
+            ccflags=ccflags,
             compiler=compiler,
             xml_generator=xml_generator,
             keep_xml=keep_xml,
@@ -398,6 +422,8 @@ def load_xml_generator_configuration(configuration, **defaults):
             cfg.keep_xml = value
         elif name == 'cflags':
             cfg.cflags = value
+        elif name == 'ccflags':
+            cfg.ccflags = value
         elif name == 'flags':
             cfg.flags = value
         elif name == 'compiler_path':

--- a/pygccxml/parser/source_reader.py
+++ b/pygccxml/parser/source_reader.py
@@ -137,7 +137,6 @@ class source_reader_t(object):
                 if self.__config.compiler == 'msvc9':
                     cmd.append('"-D_HAS_TR1=0"')
         else:
-
             # On mac or linux, use gcc or clang (the flag is the same)
             cmd.append('--castxml-cc-gnu ')
 
@@ -146,9 +145,14 @@ class source_reader_t(object):
             else:
                 std_flag = ' ' + self.__cxx_std.stdcxx + ' '
 
+            ccflags = self.__config.ccflags
             if std_flag:
+                ccflags += std_flag
+
+            if ccflags:
+                all_cc_opts = self.__config.compiler_path + ' ' + ccflags
                 cmd.append(
-                    '"(" ' + self.__config.compiler_path + std_flag + '")"')
+                    '"(" ' + all_cc_opts + ' ")"')
             else:
                 cmd.append(self.__config.compiler_path)
 

--- a/unittests/data/test_ccflags.hpp
+++ b/unittests/data/test_ccflags.hpp
@@ -1,0 +1,5 @@
+// Will only be defined when -fopenmp flag is included
+// in ccflags of corresponding config object.
+#ifdef _OPENMP
+  namespace ccflags_test_namespace{}
+#endif

--- a/unittests/test_all.py
+++ b/unittests/test_all.py
@@ -87,6 +87,7 @@ from . import test_comments
 from . import test_deprecation
 from . import test_warn_missing_include_dirs
 from . import test_overrides
+from . import test_ccflags
 
 testers = [
     pep8_tester,
@@ -170,6 +171,9 @@ testers = [
 if platform.system() != 'Windows':
     # Known to fail under windows with VS2013
     testers.append(example_tester)
+
+    # Awaiting Windows CI machine
+    testers.append(test_ccflags)
 
 if 'posix' in os.name:
     testers.append(copy_constructor_tester)

--- a/unittests/test_ccflags.py
+++ b/unittests/test_ccflags.py
@@ -1,0 +1,66 @@
+# Copyright 2014-2021 Insight Software Consortium.
+# Copyright 2004-2009 Roman Yakovenko.
+# Distributed under the Boost Software License, Version 1.0.
+# See http://www.boost.org/LICENSE_1_0.txt
+
+import unittest
+
+from . import parser_test_case
+
+from pygccxml import parser
+from pygccxml import declarations
+
+
+class Test(parser_test_case.parser_test_case_t):
+    global_ns = None
+
+    def __init__(self, *args):
+        parser_test_case.parser_test_case_t.__init__(self, *args)
+        self.header = "test_ccflags.hpp"
+        self.global_ns = None
+        self.config.castxml_epic_version = 1
+        self.config.append_cflags("-fopenmp")
+
+    def _parse_src(self):
+        decls = parser.parse([self.header], self.config)
+        Test.global_ns = declarations.get_global_namespace(decls)
+        Test.xml_generator_from_xml_file = (
+            self.config.xml_generator_from_xml_file
+        )
+        self.xml_generator_from_xml_file = Test.xml_generator_from_xml_file
+
+        self.global_ns = Test.global_ns
+
+    def _add_ccflags(self):
+        if "clang++" in self.config.compiler_path:
+            self.config.append_ccflags("-Xpreprocessor")
+
+        self.config.append_ccflags("-fopenmp")
+
+    def test(self):
+        # First check that macro is not defined.
+        self._parse_src()
+        namespace_names = [
+            n.name for n in self.global_ns.namespaces(allow_empty=True)
+        ]
+        self.assertNotIn("ccflags_test_namespace", namespace_names)
+
+        # Next check that macro is defined when passed directly as ccflag
+        self._add_ccflags()
+        self._parse_src()
+        namespace_names = [n.name for n in self.global_ns.namespaces()]
+        self.assertIn("ccflags_test_namespace", namespace_names)
+
+
+def create_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(Test))
+    return suite
+
+
+def run_suite():
+    unittest.TextTestRunner(verbosity=2).run(create_suite())
+
+
+if __name__ == "__main__":
+    run_suite()


### PR DESCRIPTION
Allow users to pass predefined macros to the simulated compiler (e.g. `-fopenmp`). By default, these are removed by castxml. Currently only supported on mac and linux.