### PR TITLE
Make type equivalence check for string and ostream more robust

### DIFF
--- a/pygccxml/declarations/type_traits.py
+++ b/pygccxml/declarations/type_traits.py
@@ -483,29 +483,21 @@ def is_fundamental(type_):
 string_equivalences = [
     (
         '::std::basic_string<char,std::char_traits<char>,'
-        'std::allocator<char> >'),
-    (
-        '::std::basic_string<char, std::char_traits<char>, '
-        'std::allocator<char> >'),
+        'std::allocator<char>>'),
     '::std::basic_string<char>', '::std::string']
 
 wstring_equivalences = [
     (
         '::std::basic_string<wchar_t,std::char_traits<wchar_t>,' +
-        'std::allocator<wchar_t> >'),
-    (
-        '::std::basic_string<wchar_t, std::char_traits<wchar_t>, ' +
-        'std::allocator<wchar_t> >'),
+        'std::allocator<wchar_t>>'),
     '::std::basic_string<wchar_t>', '::std::wstring']
 
 ostream_equivalences = [
-    '::std::basic_ostream<char, std::char_traits<char> >',
-    '::std::basic_ostream<char,std::char_traits<char> >',
+    '::std::basic_ostream<char,std::char_traits<char>>',
     '::std::basic_ostream<char>', '::std::ostream']
 
 wostream_equivalences = [
-    '::std::basic_ostream<wchar_t, std::char_traits<wchar_t> >',
-    '::std::basic_ostream<wchar_t,std::char_traits<wchar_t> >',
+    '::std::basic_ostream<wchar_t,std::char_traits<wchar_t>>',
     '::std::basic_ostream<wchar_t>', '::std::wostream']
 
 
@@ -521,7 +513,7 @@ def is_std_string(type_):
     type_ = remove_alias(type_)
     type_ = remove_reference(type_)
     type_ = remove_cv(type_)
-    return type_.decl_string in string_equivalences
+    return type_.decl_string.replace(' ', '') in string_equivalences
 
 
 def is_std_wstring(type_):
@@ -536,7 +528,7 @@ def is_std_wstring(type_):
     type_ = remove_alias(type_)
     type_ = remove_reference(type_)
     type_ = remove_cv(type_)
-    return type_.decl_string in wstring_equivalences
+    return type_.decl_string.replace(' ', '') in wstring_equivalences
 
 
 def is_std_ostream(type_):
@@ -551,7 +543,7 @@ def is_std_ostream(type_):
     type_ = remove_alias(type_)
     type_ = remove_reference(type_)
     type_ = remove_cv(type_)
-    return type_.decl_string in ostream_equivalences
+    return type_.decl_string.replace(' ', '') in ostream_equivalences
 
 
 def is_std_wostream(type_):
@@ -566,4 +558,4 @@ def is_std_wostream(type_):
     type_ = remove_alias(type_)
     type_ = remove_reference(type_)
     type_ = remove_cv(type_)
-    return type_.decl_string in wostream_equivalences
+    return type_.decl_string.replace(' ', '') in wostream_equivalences


### PR DESCRIPTION
On macOS 11.3 / Xcode 12.5 with castxml 0.4.3 installed via MacPorts, some uses of std::string were not correctly identified (the decl_string was `::std::basic_string<char,std::char_traits<char>,std::allocator<char>>`, without any spaces, which didn't match anything). This caused `decl_wrappers.python_traits.is_immutable` to return the wrong thing, which in turn caused `decl_wrappers.python_traits.call_traits` to generate broken code. This was a pain to track down. The responsible code seemed rather brittle. This is a simple attempt to make it slightly more robust.