### PR TITLE
Pass cflags to subclass

### DIFF
--- a/pygccxml/parser/config.py
+++ b/pygccxml/parser/config.py
@@ -282,6 +282,7 @@ class xml_generator_configuration_t(parser_configuration_t):
             include_paths=include_paths,
             define_symbols=define_symbols,
             undefine_symbols=undefine_symbols,
+            cflags=cflags,
             ccflags=ccflags,
             compiler=compiler,
             xml_generator=xml_generator,


### PR DESCRIPTION
Fixes an issue introduced in 17feef3 where cflags aren't always passed to subclass.