### PR TITLE
Add search_path arg

### DIFF
--- a/pygccxml/utils/utils.py
+++ b/pygccxml/utils/utils.py
@@ -32,12 +32,14 @@ def is_str(string):
     return isinstance(string, basestring)
 
 
-def find_xml_generator(name="castxml"):
+def find_xml_generator(name="castxml", search_path=None):
     """
     Try to find a c++ parser (xml generator)
 
     Args:
         name (str): name of the c++ parser (e.g. castxml)
+        search_path (str): helps finding castxml
+                           (for example in jupyter notebooks, use sys.path)
 
     Returns:
         path (str), name (str): path to the xml generator and it's name
@@ -49,7 +51,8 @@ def find_xml_generator(name="castxml"):
     """
 
     if sys.version_info[:2] >= (3, 3):
-        path = _find_xml_generator_for_python_greater_equals_33(name)
+        path = _find_xml_generator_for_python_greater_equals_33(
+            name, search_path=search_path)
     else:
         path = _find_xml_generator_for_legacy_python(name)
 
@@ -58,8 +61,8 @@ def find_xml_generator(name="castxml"):
     return path.rstrip(), name
 
 
-def _find_xml_generator_for_python_greater_equals_33(name):
-    return shutil.which(name)
+def _find_xml_generator_for_python_greater_equals_33(name, search_path=None):
+    return shutil.which(name, path=search_path)
 
 
 def _find_xml_generator_for_legacy_python(name):


### PR DESCRIPTION
I find shutils only use PATH rather than sys.path. In jupyter it usually is the environment of the jupyter rather than the kernel. Adding this helps it search for castxml.