### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Changes
 Version 2.4.0
 -------------
 
-1. Add official support for `Python 3.9`, `Python 3.10`, `Python 3.11`
+1. Drop support for `Python 3.6`
+
+2. Add official support for `Python 3.9`, `Python 3.10`, `Python 3.11`
 
 Version 2.3.0
 -------------

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Install instructions can be found `here <http://pygccxml.readthedocs.io/en/maste
 Compatibility
 -------------
 
-pygccxml is compatible with Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11 and pypy3.
+pygccxml is compatible with Python 3.7, 3.8, 3.9, 3.10, 3.11 and pypy3.
 
 Documentation and examples
 --------------------------


### PR DESCRIPTION
Follow up from https://github.com/CastXML/pygccxml/pull/159