### PR TITLE
Build: pyproject.xml fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygccxml"


### PR DESCRIPTION
commit 97498ae39322fd228d10d5e099cbe11f97e9f384
Author:     Michał Górny <mgorny@gentoo.org>
AuthorDate: 2023-08-22 05:54:54 +0200
Commit:     Michał Górny <mgorny@gentoo.org>
CommitDate: 2023-08-22 05:55:20 +0200

    Build: Remove redundant wheel dep from pyproject.toml
    
    Remove the redundant `wheel` dependency, as it is added by the backend
    automatically.  Listing it explicitly in the documentation was
    a historical mistake and has been fixed since, see:
    https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a

commit df8e4074998afe15593bead59674ebdad9d59676
Author:     Michał Górny <mgorny@gentoo.org>
AuthorDate: 2023-08-22 05:50:07 +0200
Commit:     Michał Górny <mgorny@gentoo.org>
CommitDate: 2023-08-22 05:50:07 +0200

    Build: Use non-legacy setuptools backend
    
    Use the modern `setuptools.build_meta` backend rather than the legacy
    backend that is implied by the lack of `build-backend`.
    
    This is documented in PEP 517:
    
    > If the `pyproject.toml` file is absent, or the `build-backend` key is
    > missing, the source tree is not using this specification, and tools
    > should revert to the legacy behaviour of running `setup.py` (either
    > directly, or by implicitly invoking
    > the `setuptools.build_meta:__legacy__` backend).
    
    https://peps.python.org/pep-0517/#source-trees
