### PR TITLE
tests: remove codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,12 +102,3 @@ jobs:
           coverage run -m unittests.test_all
           coverage combine
           coverage xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.xml
-          flags: unittests
-          env_vars: OS,PYTHON
-          name: codecov-umbrella
-          fail_ci_if_error: true


### PR DESCRIPTION
Needs another token. Will add codecov back later.
This is just to unblock the CI