### PR TITLE
Use `shutil.which()` to get compiler path

### DIFF
--- a/src/pygccxml/parser/config.py
+++ b/src/pygccxml/parser/config.py
@@ -11,6 +11,7 @@ Defines C++ parser configuration classes.
 import os
 import copy
 import platform
+import shutil
 import subprocess
 import warnings
 # In py3, ConfigParser was renamed to the more-standard configparser.
@@ -451,34 +452,19 @@ def create_compiler_path(xml_generator, compiler_path):
     if xml_generator == 'castxml' and compiler_path is None:
         if platform.system() == 'Windows':
             # Look for msvc
-            compiler_path = __get_first_compiler_in_path('where', 'cl')
+            compiler_path = shutil.which('cl')
             # No msvc found; look for mingw
-            if compiler_path == '':
-                compiler_path = __get_first_compiler_in_path('where', 'mingw')
+            if compiler_path is None:
+                compiler_path = shutil.which('mingw')
         else:
             # OS X or Linux
             # Look for clang first, then gcc
-            compiler_path = __get_first_compiler_in_path('which', 'clang++')
+            compiler_path = shutil.which('clang++')
             # No clang found; use gcc
-            if compiler_path == '':
-                compiler_path = __get_first_compiler_in_path('which', 'c++')
-
-        if compiler_path == "":
-            compiler_path = None
+            if compiler_path is None:
+                compiler_path = shutil.which('c++')
 
     return compiler_path
-
-
-def __get_first_compiler_in_path(command, compiler_name):
-    p = subprocess.Popen(
-        [command, compiler_name],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
-    path = p.stdout.read().decode("utf-8").rstrip().split("\r\n")[0].rstrip()
-    p.wait()
-    p.stdout.close()
-    p.stderr.close()
-    return path
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Remove the `__get_first_compiler_in_path()` function that used `which(1)` / `where` program to get the compiler path, with built-in `shutil.which()`.  This fixes pygccxml on systems where `which(1)` is no longer present (it is not a standard POSIX tool, and Linux distributions are working towards making it optional).