### PR TITLE
scanner.py: add support for "original_type" attribute of "Argument" XML tag

### DIFF
--- a/src/pygccxml/parser/scanner.py
+++ b/src/pygccxml/parser/scanner.py
@@ -56,6 +56,7 @@ XML_AN_SIZE = "size"
 XML_AN_STATIC = "static"
 XML_AN_THROW = "throw"
 XML_AN_TYPE = "type"
+XML_AN_ORIGINAL_TYPE = "original_type"
 XML_AN_VIRTUAL = "virtual"
 XML_AN_VOLATILE = "volatile"
 XML_NN_ARGUMENT = "Argument"
@@ -558,7 +559,10 @@ class scanner_t(xml.sax.handler.ContentHandler):
                 XML_AN_NAME,
                 'arg%d' % len(
                     self.__inst.arguments))
-            argument.decl_type = attrs[XML_AN_TYPE]
+            argument.decl_type = attrs.get(
+                XML_AN_ORIGINAL_TYPE,
+                attrs.get(XML_AN_TYPE)
+            )
             argument.default_value = attrs.get(XML_AN_DEFAULT)
             self.__read_attributes(argument, attrs)
             self.__inst.arguments.append(argument)

--- a/tests/test_array_argument.py
+++ b/tests/test_array_argument.py
@@ -1,0 +1,76 @@
+# Copyright 2014-2017 Insight Software Consortium.
+# Copyright 2004-2009 Roman Yakovenko.
+# Distributed under the Boost Software License, Version 1.0.
+# See http://www.boost.org/LICENSE_1_0.txt
+
+import unittest
+
+from . import parser_test_case
+
+from pygccxml import parser
+from pygccxml import declarations
+
+
+class Test(parser_test_case.parser_test_case_t):
+
+    def __init__(self, *args):
+        parser_test_case.parser_test_case_t.__init__(self, *args)
+        self.header = "test_array_argument.hpp"
+        self.config.cflags = "-std=c++11"
+
+    def test_array_argument(self):
+
+        """
+        Test to ensure that function arguments' array size are kept intact
+        rather than presented as pointers.
+
+        """
+
+        decls = parser.parse([self.header], self.config)
+        global_ns = declarations.get_global_namespace(decls)
+
+        criteria = declarations.calldef_matcher(name="function")
+        free_funcs = declarations.matcher.find(criteria, global_ns)
+        for free_func in free_funcs:
+            decl_string = free_func.create_decl_string(with_defaults=False)
+            self.assertEqual(
+                decl_string,
+                "void ( ::test::* )( int [1024],int [512] )"
+            )
+            arg1 = free_func.arguments[0]
+            arg2 = free_func.arguments[1]
+            self.assertEqual(arg1.decl_type.decl_string, "int [1024]")
+            self.assertEqual(arg1.name, "arg1")
+            self.assertEqual(
+                declarations.type_traits.array_size(arg1.decl_type),
+                1024
+            )
+            self.assertIsInstance(
+                declarations.type_traits.array_item_type(arg1.decl_type),
+                declarations.cpptypes.int_t
+            )
+            self.assertEqual(arg2.decl_type.decl_string, "int [512]")
+            self.assertEqual(arg2.name, "arg2")
+            self.assertEqual(
+                declarations.type_traits.array_size(arg2.decl_type),
+                512
+            )
+            self.assertIsInstance(
+                declarations.type_traits.array_item_type(arg2.decl_type),
+                declarations.cpptypes.int_t
+            )
+
+
+def create_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(
+        unittest.TestLoader().loadTestsFromTestCase(testCaseClass=Test))
+    return suite
+
+
+def run_suite():
+    unittest.TextTestRunner(verbosity=2).run(create_suite())
+
+
+if __name__ == "__main__":
+    run_suite()

--- a/unittests/data/test_array_argument.hpp
+++ b/unittests/data/test_array_argument.hpp
@@ -1,0 +1,13 @@
+// Copyright 2014-2017 Insight Software Consortium.
+// Copyright 2004-2009 Roman Yakovenko.
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+
+class test
+{
+    public:
+        // A constructor
+        test(const float & t0){};
+
+        void function(int arg1[1024], int arg2[512]) {};
+};


### PR DESCRIPTION
scanner.py: add support for "original_type" attribute of "Argument" XML tag. For array args this means avoiding losing the delcared width of the array and having its decl_type show as pointer_t.

Fall back on "type" (current default-no-matter-what) attribute when "original_type" is not present.

XML generated by pygccxml+CastXML:
![image](https://github.com/user-attachments/assets/7f4a5dd0-cd0d-4286-9bf8-1fd84d7cee93)
![image](https://github.com/user-attachments/assets/5a2585c0-d02e-4b3f-a504-99cd5b045713)
![image](https://github.com/user-attachments/assets/d5abc2b6-9950-4f04-a328-e383c06d550d)

Behaviour:
```python
classes_obj                       = global_ns.classes()
class_im_looking_for              = [d for d in classes_obj.declarations if "class_im_looking_for" in d.name][0]
method_im_looking_for_declaration = [d for d in class_im_looking_for.declarations if d.name == "method_name"][0]
method_arguments                  = method_im_looking_for_declaration.arguments
argument                          = method_arguments[0]

# pre-PR this gives:
argument.decl_type.decl_string
Out[2]: '::my_namespace::my_type *'
pygccxml.declarations.type_traits.array_size(argument.decl_type)
#AssertionError: 
#> path/to/site-packages/pygccxml/declarations/type_traits.py(293)array_size()
#    291     nake_type = remove_reference(nake_type)
#    292     nake_type = remove_cv(nake_type)
#--> 293     assert isinstance(nake_type, cpptypes.array_t)
#    294     return nake_type.size

# post-PR this gives:
argument.decl_type.decl_string
Out[4]: '::my_namespace::my_type[1024]'
pygccxml.declarations.type_traits.array_size(argument.decl_type)
Out[5]: 1024
```