### PR TITLE
tests: fix compilation with c++14/17

### DIFF
--- a/tests/data/core_types.hpp
+++ b/tests/data/core_types.hpp
@@ -48,13 +48,11 @@ typedef EFavoriteDrinks typedef_EFavoriteDrinks;
 
 typedef int (*function_ptr)(int, double);
 
-struct exception{};
-
 struct members_pointers_t{
 	int some_function( double hi, int i ){
 		return 0;
 	}
-	int some_function( double hi) const throw( exception ){
+	int some_function( double hi) const {
 		return 0;
 	};
     int m_some_const_member;


### PR DESCRIPTION
Fixes:
---------------------------- Captured stderr setup ----------------------------- /<<PKGBUILDDIR>>/.pybuild/cpython3_3.12_pygccxml/build/tests/data/core_types.hpp:57:38: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
   57 |         int some_function( double hi) const throw( exception ){
      |                                             ^~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/.pybuild/cpython3_3.12_pygccxml/build/tests/data/core_types.hpp:57:38: note: use 'noexcept(false)' instead
   57 |         int some_function( double hi) const throw( exception ){
      |                                             ^~~~~~~~~~~~~~~~~~
      |                                             noexcept(false)
1 error generated.

-----

No need to keep the throws / or to replace it with noexcept. We are not really testing this functionality here, so lets write code that is generic enough for all c++ versions