### PR TITLE
type-traits: fix string equivalences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,6 @@ docs = [
 examples = [
   "notebook",
 ]
+[tool.pytest.ini_options]
+ pythonpath = [
+   "src"]

--- a/src/pygccxml/declarations/container_traits.py
+++ b/src/pygccxml/declarations/container_traits.py
@@ -29,20 +29,17 @@ class defaults_eraser(object):
         return type_str.replace(' ', '')
 
     def replace_basic_string(self, cls_name):
-
-        # Take the lists of all possible string variations
-        # and clean them up by replacing ::std by std.
-        str_eq = [
-            v.replace("::std", "std") for v in
-            type_traits.string_equivalences]
-        wstr_eq = [
-            v.replace("::std", "std") for v in
-            type_traits.wstring_equivalences]
-
         # Replace all the variations of strings by the smallest one.
         strings = {
-            "std::string": [v for v in str_eq if not v == "std::string"],
-            "std::wstring": [v for v in wstr_eq if not v == "std::wstring"]}
+            "std::string":
+                [v for v in
+                 type_traits.normalized_string_equivalences
+                 if not v == "std::string"],
+            "std::wstring":
+                [v for v in
+                 type_traits.normalized_wstring_equivalences
+                 if not v == "std::wstring"]
+            }
 
         new_name = cls_name
         for short_name, long_names in strings.items():

--- a/src/pygccxml/declarations/type_traits.py
+++ b/src/pygccxml/declarations/type_traits.py
@@ -480,25 +480,53 @@ def is_fundamental(type_):
             (cpptypes.volatile_t, cpptypes.const_t))
 
 
+def _normalize(string):
+    return string.replace(' ', '').replace("::std", "std")
+
+
+def _normalize_equivalences(equivalences):
+    return [_normalize(eq) for eq in equivalences]
+
+
 string_equivalences = [
     (
-        '::std::basic_string<char,std::char_traits<char>,'
-        'std::allocator<char>>'),
-    '::std::basic_string<char>', '::std::string']
+        '::std::basic_string<char, std::char_traits<char>, '
+        'std::allocator<char>>'
+    ),
+    '::std::basic_string<char>',
+    '::std::string'
+    ]
 
 wstring_equivalences = [
     (
-        '::std::basic_string<wchar_t,std::char_traits<wchar_t>,' +
-        'std::allocator<wchar_t>>'),
-    '::std::basic_string<wchar_t>', '::std::wstring']
+        '::std::basic_string<wchar_t, std::char_traits<wchar_t>, '
+        'std::allocator<wchar_t>>'
+    ),
+    '::std::basic_string<wchar_t>',
+    '::std::wstring'
+    ]
 
 ostream_equivalences = [
-    '::std::basic_ostream<char,std::char_traits<char>>',
+    '::std::basic_ostream<char, std::char_traits<char>>',
     '::std::basic_ostream<char>', '::std::ostream']
 
 wostream_equivalences = [
-    '::std::basic_ostream<wchar_t,std::char_traits<wchar_t>>',
+    '::std::basic_ostream<wchar_t, std::char_traits<wchar_t>>',
     '::std::basic_ostream<wchar_t>', '::std::wostream']
+
+
+normalized_string_equivalences = _normalize_equivalences(
+    string_equivalences
+    )
+normalized_wstring_equivalences = _normalize_equivalences(
+    wstring_equivalences
+    )
+normalized_ostream_equivalences = _normalize_equivalences(
+    ostream_equivalences
+    )
+normalized_wostream_equivalences = _normalize_equivalences(
+    wostream_equivalences
+    )
 
 
 def is_std_string(type_):
@@ -508,12 +536,12 @@ def is_std_string(type_):
     """
 
     if isinstance(type_, str):
-        return type_ in string_equivalences
+        return _normalize(type_) in normalized_string_equivalences
 
     type_ = remove_alias(type_)
     type_ = remove_reference(type_)
     type_ = remove_cv(type_)
-    return type_.decl_string.replace(' ', '') in string_equivalences
+    return _normalize(type_.decl_string) in normalized_string_equivalences
 
 
 def is_std_wstring(type_):
@@ -523,12 +551,12 @@ def is_std_wstring(type_):
     """
 
     if isinstance(type_, str):
-        return type_ in wstring_equivalences
+        return _normalize(type_) in normalized_wstring_equivalences
 
     type_ = remove_alias(type_)
     type_ = remove_reference(type_)
     type_ = remove_cv(type_)
-    return type_.decl_string.replace(' ', '') in wstring_equivalences
+    return _normalize(type_.decl_string) in normalized_wstring_equivalences
 
 
 def is_std_ostream(type_):
@@ -538,12 +566,12 @@ def is_std_ostream(type_):
     """
 
     if isinstance(type_, str):
-        return type_ in ostream_equivalences
+        return _normalize(type_) in normalized_ostream_equivalences
 
     type_ = remove_alias(type_)
     type_ = remove_reference(type_)
     type_ = remove_cv(type_)
-    return type_.decl_string.replace(' ', '') in ostream_equivalences
+    return _normalize(type_.decl_string) in normalized_ostream_equivalences
 
 
 def is_std_wostream(type_):
@@ -553,9 +581,9 @@ def is_std_wostream(type_):
     """
 
     if isinstance(type_, str):
-        return type_ in wostream_equivalences
+        return _normalize(type_) in normalized_wostream_equivalences
 
     type_ = remove_alias(type_)
     type_ = remove_reference(type_)
     type_ = remove_cv(type_)
-    return type_.decl_string.replace(' ', '') in wostream_equivalences
+    return _normalize(type_.decl_string) in normalized_wostream_equivalences


### PR DESCRIPTION
Add missing spaces, which should fix some equivalence detection in the defaults_eraser function