### PR TITLE
tests: fix some tests on macOS

### DIFF
--- a/tests/test_map_gcc5.py
+++ b/tests/test_map_gcc5.py
@@ -3,6 +3,8 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See http://www.boost.org/LICENSE_1_0.txt
 
+import platform
+
 from . import autoconfig
 
 from pygccxml import parser
@@ -22,7 +24,12 @@ def test_map_gcc5():
     """
 
     config = autoconfig.cxx_parsers_cfg.config.clone()
-    config.cflags = "-std=c++11"
+    if platform.system() == "Darwin":
+        config.cflags = "-std=c++11 -Dat_quick_exit=atexit -Dquick_exit=exit"
+        # https://fr.mathworks.com/matlabcentral/answers/2013982-clibgen-generatelibrarydefinition-error-the-global-scope-has-no-quick_exit-on-mac-m2#answer_1439856
+        # https://github.com/jetbrains/kotlin/commit/d50f585911dedec5723213da8835707ac95e1c01
+    else:
+        config.cflags = "-std=c++11"
 
     decls = parser.parse(TEST_FILES, config)
     global_ns = declarations.get_global_namespace(decls)

--- a/tests/test_pattern_parser.py
+++ b/tests/test_pattern_parser.py
@@ -4,6 +4,7 @@
 # See http://www.boost.org/LICENSE_1_0.txt
 
 import pytest
+import platform
 
 from . import autoconfig
 
@@ -20,7 +21,12 @@ TEST_FILES = [
 def global_ns():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     config = autoconfig.cxx_parsers_cfg.config.clone()
-    config.cflags = "-std=c++11"
+    if platform.system() == "Darwin":
+        config.cflags = "-std=c++11 -Dat_quick_exit=atexit -Dquick_exit=exit"
+        # https://fr.mathworks.com/matlabcentral/answers/2013982-clibgen-generatelibrarydefinition-error-the-global-scope-has-no-quick_exit-on-mac-m2#answer_1439856
+        # https://github.com/jetbrains/kotlin/commit/d50f585911dedec5723213da8835707ac95e1c01
+    else:
+        config.cflags = "-std=c++11"
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     global_ns = declarations.get_global_namespace(decls)
     global_ns.init_optimizer()

--- a/tests/test_smart_pointer.py
+++ b/tests/test_smart_pointer.py
@@ -4,6 +4,7 @@
 # See http://www.boost.org/LICENSE_1_0.txt
 
 import pytest
+import platform
 
 from . import autoconfig
 
@@ -20,7 +21,12 @@ TEST_FILES = [
 def global_ns():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     config = autoconfig.cxx_parsers_cfg.config.clone()
-    config.cflags = "-std=c++11"
+    if platform.system() == "Darwin":
+        config.cflags = "-std=c++11 -Dat_quick_exit=atexit -Dquick_exit=exit"
+        # https://fr.mathworks.com/matlabcentral/answers/2013982-clibgen-generatelibrarydefinition-error-the-global-scope-has-no-quick_exit-on-mac-m2#answer_1439856
+        # https://github.com/jetbrains/kotlin/commit/d50f585911dedec5723213da8835707ac95e1c01
+    else:
+        config.cflags = "-std=c++11"
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     global_ns = declarations.get_global_namespace(decls)
     global_ns.init_optimizer()


### PR DESCRIPTION
Fixes:
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/cstdlib:144:9: error: no member named 'at_quick_exit' in the global namespace using ::at_quick_exit _LIBCPP_USING_IF_EXISTS;
      ~~^
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/cstdlib:145:9: error: no member named 'quick_exit' in the global namespace using ::quick_exit _LIBCPP_USING_IF_EXISTS;
      ~~^