### PR TITLE
tests: fix more tests on macOS

### DIFF
--- a/tests/test_cpp_standards.py
+++ b/tests/test_cpp_standards.py
@@ -20,27 +20,34 @@ def test_cpp_standards():
 
     config = autoconfig.cxx_parsers_cfg.config.clone()
 
+    cflags_common = ""
+
+    if platform.system() == "Darwin":
+        cflags_common = " -Dat_quick_exit=atexit -Dquick_exit=exit"
+        # https://fr.mathworks.com/matlabcentral/answers/2013982-clibgen-generatelibrarydefinition-error-the-global-scope-has-no-quick_exit-on-mac-m2#answer_1439856
+        # https://github.com/jetbrains/kotlin/commit/d50f585911dedec5723213da8835707ac95e1c01
+
     parser.parse(["cpp_standards.hpp"], config)
 
     if platform.system() != 'Windows':
-        config.cflags = "-std=c++98"
+        config.cflags = "-std=c++98" + cflags_common
         parser.parse(["cpp_standards.hpp"], config)
 
-        config.cflags = "-std=c++03"
+        config.cflags = "-std=c++03" + cflags_common
         parser.parse(["cpp_standards.hpp"], config)
 
-    config.cflags = "-std=c++11"
+    config.cflags = "-std=c++11" + cflags_common
 
     parser.parse(["cpp_standards.hpp"], config)
 
-    config.cflags = "-std=c++14"
+    config.cflags = "-std=c++14" + cflags_common
     parser.parse(["cpp_standards.hpp"], config)
 
-    config.cflags = "-std=c++1z"
+    config.cflags = "-std=c++1z" + cflags_common
     parser.parse(["cpp_standards.hpp"], config)
 
     # Pass down a flag that does not exist.
     # This should raise an exception.
-    config.cflags = "-std=c++00"
+    config.cflags = "-std=c++00" + cflags_common
     with pytest.raises(RuntimeError):
         parser.parse(["cpp_standards.hpp"], config)

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -4,6 +4,7 @@
 # See http://www.boost.org/LICENSE_1_0.txt
 
 import pytest
+import platform
 
 from . import autoconfig
 
@@ -15,7 +16,12 @@ from pygccxml import declarations
 def global_ns_fixture():
     config = autoconfig.cxx_parsers_cfg.config.clone()
     config.castxml_epic_version = 1
-    config.cflags = "-std=c++11"
+    if platform.system() == "Darwin":
+        config.cflags = "-std=c++11 -Dat_quick_exit=atexit -Dquick_exit=exit"
+        # https://fr.mathworks.com/matlabcentral/answers/2013982-clibgen-generatelibrarydefinition-error-the-global-scope-has-no-quick_exit-on-mac-m2#answer_1439856
+        # https://github.com/jetbrains/kotlin/commit/d50f585911dedec5723213da8835707ac95e1c01
+    else:
+        config.cflags = "-std=c++11"
     decls = parser.parse(["test_overrides.hpp"], config)
     global_ns = declarations.get_global_namespace(decls)
     return global_ns

--- a/tests/test_pattern_parser.py
+++ b/tests/test_pattern_parser.py
@@ -40,7 +40,12 @@ def test_template_split_std_vector(global_ns):
     """
 
     config = autoconfig.cxx_parsers_cfg.config.clone()
-    config.cflags = "-std=c++11"
+    if platform.system() == "Darwin":
+        config.cflags = "-std=c++11 -Dat_quick_exit=atexit -Dquick_exit=exit"
+        # https://fr.mathworks.com/matlabcentral/answers/2013982-clibgen-generatelibrarydefinition-error-the-global-scope-has-no-quick_exit-on-mac-m2#answer_1439856
+        # https://github.com/jetbrains/kotlin/commit/d50f585911dedec5723213da8835707ac95e1c01
+    else:
+        config.cflags = "-std=c++11"
     decls = parser.parse(TEST_FILES, config)
 
     for decl in declarations.make_flatten(decls):


### PR DESCRIPTION
Fixes:
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/cstdlib:144:9: error: no member named 'at_quick_exit' in the global namespace using ::at_quick_exit _LIBCPP_USING_IF_EXISTS;
      ~~^
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/cstdlib:145:9: error: no member named 'quick_exit' in the global namespace using ::quick_exit _LIBCPP_USING_IF_EXISTS;
      ~~^
2 errors generated.