### PR TITLE
Fix errors due to dynamic exception specification

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - develop
+      - dynamic_exception
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,6 @@ on:
     branches:
       - main
       - develop
-      - dynamic_exception
   pull_request:
 
 jobs:

--- a/tests/test_calldef_matcher.py
+++ b/tests/test_calldef_matcher.py
@@ -20,6 +20,7 @@ TEST_FILES = [
 def decls():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     return decls
 

--- a/tests/test_decl_string.py
+++ b/tests/test_decl_string.py
@@ -21,6 +21,7 @@ def global_ns():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     INIT_OPTIMIZER = True
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     config.castxml_epic_version = 1
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     global_ns = declarations.get_global_namespace(decls)
@@ -38,6 +39,7 @@ TEMPLATE = """
 
 def test_member_function(global_ns):
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     member_inline_call = \
         global_ns.member_function('member_inline_call')
     decls = parser.parse_string(
@@ -49,6 +51,7 @@ def test_member_function(global_ns):
 
 def test_free_function(global_ns):
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     return_default_args = \
         global_ns.free_function('return_default_args')
     decls = parser.parse_string(
@@ -60,6 +63,7 @@ def test_free_function(global_ns):
 
 def test_all_mem_and_free_funs(global_ns):
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     ns = global_ns.namespace('::declarations::calldef')
     for f in ns.member_functions():
         decls = parser.parse_string(

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -21,6 +21,7 @@ TEST_FILES = [
 def global_ns_fixture_all_at_once():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     global_ns = declarations.get_global_namespace(decls)
     return global_ns
@@ -30,6 +31,7 @@ def global_ns_fixture_all_at_once():
 def global_ns_fixture_file_by_file():
     COMPILATION_MODE = parser.COMPILATION_MODE.FILE_BY_FILE
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     global_ns = declarations.get_global_namespace(decls)
     return global_ns

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -21,6 +21,7 @@ def global_ns():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     INIT_OPTIMIZER = True
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     config.castxml_epic_version = 1
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     global_ns = declarations.get_global_namespace(decls)

--- a/tests/test_filters_tester.py
+++ b/tests/test_filters_tester.py
@@ -17,6 +17,7 @@ TEST_FILES = ['declarations_calldef.hpp']
 def global_ns():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     global_ns = declarations.get_global_namespace(decls)
     global_ns.init_optimizer()

--- a/tests/test_source_reader.py
+++ b/tests/test_source_reader.py
@@ -21,6 +21,7 @@ TEST_FILES = [
 def global_ns():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     if platform.system() == "Darwin":
         config.cflags = "-Dat_quick_exit=atexit -Dquick_exit=exit"
         # https://fr.mathworks.com/matlabcentral/answers/2013982-clibgen-generatelibrarydefinition-error-the-global-scope-has-no-quick_exit-on-mac-m2#answer_1439856

--- a/tests/test_type_as_exception_bug.py
+++ b/tests/test_type_as_exception_bug.py
@@ -20,6 +20,7 @@ TEST_FILES = [
 def global_ns():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    config.cflags = "-std=c++14"
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     global_ns = declarations.get_global_namespace(decls)
     return global_ns


### PR DESCRIPTION
As c++17 does no longer allow dynamic exception specification the test mentioned in the PR should be restricted to c++14. Otherwise the tests will fail on modern Compilers with:

`RuntimeError: Error occurred while running CASTXML xml file does not exist`.