### PR TITLE
PART 1: Update tests.yml to use artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,9 +79,9 @@ jobs:
             cppstd: "-std=c++98"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -93,13 +93,13 @@ jobs:
         run: pycodestyle . --exclude=docs
 
       # ─── Setup CastXML for Linux ARM64 ──────────────────────────────
-      - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
+      - name: Setup CastXML for Linux x86_64 (Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04'
         run: |
           wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz
           tar -xzf ~/castxml-ubuntu-22.04-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
-      - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
+      - name: Setup CastXML for Linux x86_64 (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04'
         run: |
           wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-x86_64.tar.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,34 +92,30 @@ jobs:
       - name: Run pycodestyle
         run: pycodestyle . --exclude=docs
 
-            # ─── Setup CastXML para Linux ARM64 ──────────────────────────────
+            # ─── Setup CastXML for Linux ARM64 ──────────────────────────────
       - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04-arm64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-ubuntu-22.04-arm-aarch64.zip
-          unzip -q castxml-ubuntu-22.04-arm-aarch64.zip -d ~/
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-ubuntu-22.04-arm-aarch64.tar.gz
           tar -xzf ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04-arm64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-ubuntu-24.04-arm-aarch64.zip
-          unzip -q castxml-ubuntu-24.04-arm-aarch64.zip -d ~/
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-ubuntu-24.04-arm-aarch64.tar.gz
           tar -xzf ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
-      # ─── Setup CastXML para macOS ─────────────────────────────────────
+      # ─── Setup CastXML for macOS ─────────────────────────────────────
       - name: Setup CastXML for macOS (x86_64)
         if: matrix.os == 'macos-15' && matrix.arch == 'x86_64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-macos-15-x86_64.zip
-          unzip -q castxml-macos-15-x86_64.zip -d ~/
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-macos-15-x86_64.tar.gz
           tar -xzf ~/castxml-macos-15-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Setup CastXML for macOS (ARM)
         if: matrix.os == 'macos-15' && matrix.arch == 'arm64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-macos-15-arm64.zip
-          unzip -q castxml-macos-15-arm64.zip -d ~/
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-macos-15-arm64.tar.gz
           tar -xzf ~/castxml-macos-15-arm64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,26 +96,26 @@ jobs:
       - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04-arm64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-ubuntu-22.04-arm-aarch64.tar.gz
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-arm-aarch64.tar.gz
           tar -xzf ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04-arm64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-ubuntu-24.04-arm-aarch64.tar.gz
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-arm-aarch64.tar.gz
           tar -xzf ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       # ─── Setup CastXML for macOS ─────────────────────────────────────
       - name: Setup CastXML for macOS (x86_64)
         if: matrix.os == 'macos-15' && matrix.arch == 'x86_64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-macos-15-x86_64.tar.gz
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-x86_64.tar.gz
           tar -xzf ~/castxml-macos-15-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Setup CastXML for macOS (ARM)
         if: matrix.os == 'macos-15' && matrix.arch == 'arm64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-macos-15-arm64.tar.gz
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-arm64.tar.gz
           tar -xzf ~/castxml-macos-15-arm64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
             castxml-epic: 1
             cppstd: "-std=c++11"
 
-          - os: macos-13
+          - os: macos-15
             compiler: xcode
             version: "default"
             python-version: "3.13"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
             version: "9"
             python-version: "3.9"
@@ -22,7 +22,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
             version: "9"
             python-version: "3.10"
@@ -30,7 +30,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
             version: "9"
             python-version: "3.11"
@@ -38,7 +38,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
             version: "9"
             python-version: "3.12"
@@ -46,7 +46,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
             version: "9"
             python-version: "3.13"
@@ -54,7 +54,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
             version: "9"
             python-version: "3.13"
@@ -62,7 +62,7 @@ jobs:
             castxml-epic: 1
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
             version: "9"
             python-version: "3.13"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,39 +96,39 @@ jobs:
       - name: Setup CastXML for Linux x86_64 (Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz
+          wget -q -O https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz
           tar -xzf ~/castxml-ubuntu-22.04-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Setup CastXML for Linux x86_64 (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-x86_64.tar.gz
+          wget -q -O https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-x86_64.tar.gz
           tar -xzf ~/castxml-ubuntu-24.04-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       # ─── Setup CastXML for Linux ARM64 ──────────────────────────────
       - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04-arm64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-arm-aarch64.tar.gz
+          wget -q -O https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-arm-aarch64.tar.gz
           tar -xzf ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04-arm64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-arm-aarch64.tar.gz
+          wget -q -O https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-arm-aarch64.tar.gz
           tar -xzf ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       # ─── Setup CastXML for macOS ─────────────────────────────────────
       - name: Setup CastXML for macOS (x86_64)
         if: matrix.os == 'macos-15' && matrix.arch == 'x86_64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-x86_64.tar.gz
+          wget -q -O https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-x86_64.tar.gz
           tar -xzf ~/castxml-macos-15-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Setup CastXML for macOS (ARM)
         if: matrix.os == 'macos-15' && matrix.arch == 'arm64'
         run: |
-          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-arm64.tar.gz
+          wget -q -O https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-arm64.tar.gz
           tar -xzf ~/castxml-macos-15-arm64.tar.gz -C ~/
           chmod +x ~/castxml/castxml
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,20 @@ jobs:
       - name: Run pycodestyle
         run: pycodestyle . --exclude=docs
 
-            # ─── Setup CastXML for Linux ARM64 ──────────────────────────────
+      # ─── Setup CastXML for Linux ARM64 ──────────────────────────────
+      - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz
+          tar -xzf ~/castxml-ubuntu-22.04-x86_64.tar.gz -C ~/
+          chmod +x ~/castxml/castxml
+      - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-x86_64.tar.gz
+          tar -xzf ~/castxml-ubuntu-24.04-x86_64.tar.gz -C ~/
+          chmod +x ~/castxml/castxml
+      # ─── Setup CastXML for Linux ARM64 ──────────────────────────────
       - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04-arm64'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,14 +91,37 @@ jobs:
           pip install '.[test]'
       - name: Run pycodestyle
         run: pycodestyle . --exclude=docs
-      - name: Setup castxml for Linux
-        if: matrix.os == 'ubuntu-20.04' && matrix.castxml == 'castxml'
+
+            # ─── Setup CastXML para Linux ARM64 ──────────────────────────────
+      - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
+        if: matrix.os == 'ubuntu-22.04-arm64'
         run: |
-          wget -q -O - https://data.kitware.com/api/v1/file/hashsum/sha512/bdbb67a10c5f8d1b738cd19cb074f409d4803e8077cb8c1072ef4eaf738fa871a73643f9c8282d58cae28d188df842c82ad6620b6d590b0396a0172a27438dce/download | tar zxf - -C ~/
-      - name: Setup castxml for Mac
-        if: matrix.os == 'macos-13'
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-ubuntu-22.04-arm-aarch64.zip
+          unzip -q castxml-ubuntu-22.04-arm-aarch64.zip -d ~/
+          tar -xzf ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz -C ~/
+          chmod +x ~/castxml/castxml
+      - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04-arm64'
         run: |
-          wget -q -O - https://data.kitware.com/api/v1/file/hashsum/sha512/5d937e938f7b882a3a3e7941e68f8312d0898aaf2082e00003dd362b1ba70b98b0a08706a1be28e71652a6a0f1e66f89768b5eaa20e5a100592d5b3deefec3f0/download | tar zxf - -C ~/
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-ubuntu-24.04-arm-aarch64.zip
+          unzip -q castxml-ubuntu-24.04-arm-aarch64.zip -d ~/
+          tar -xzf ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz -C ~/
+          chmod +x ~/castxml/castxml
+      # ─── Setup CastXML para macOS ─────────────────────────────────────
+      - name: Setup CastXML for macOS (x86_64)
+        if: matrix.os == 'macos-15' && matrix.arch == 'x86_64'
+        run: |
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-macos-15-x86_64.zip
+          unzip -q castxml-macos-15-x86_64.zip -d ~/
+          tar -xzf ~/castxml-macos-15-x86_64.tar.gz -C ~/
+          chmod +x ~/castxml/castxml
+      - name: Setup CastXML for macOS (ARM)
+        if: matrix.os == 'macos-15' && matrix.arch == 'arm64'
+        run: |
+          wget -q https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11/castxml-macos-15-arm64.zip
+          unzip -q castxml-macos-15-arm64.zip -d ~/
+          tar -xzf ~/castxml-macos-15-arm64.tar.gz -C ~/
+          chmod +x ~/castxml/castxml
       - name: Run tests
         run: |
           export PATH=~/castxml/bin:$PATH


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/tests.yml` file to improve the setup process for CastXML on various operating systems and architectures. The main changes involve adding specific setup steps for different versions of Linux ARM64 and macOS.

Setup improvements:

* Added setup steps for CastXML on Linux ARM64 for Ubuntu 22.04 and Ubuntu 24.04.
* Added setup steps for CastXML on macOS for both x86_64 and ARM architectures.

cc @iMichka @thewtex fixed with https://github.com/CastXML/CastXMLSuperbuild/pull/66