### PR TITLE
tests: extract dynamic exception tests

### DIFF
--- a/src/pygccxml/declarations/calldef.py
+++ b/src/pygccxml/declarations/calldef.py
@@ -266,12 +266,24 @@ class calldef_t(declaration.declaration_t):
 
     @property
     def exceptions(self):
-        """The list of exceptions.
-            @type: list of :class:`declaration_t`"""
+        """
+        The list of exceptions.
+
+        Useless with c++17 and above as dynamich exceptions
+        are not allowed anymore:
+        https://developers.redhat.com/articles/2021/08/06/porting-your-code-c17-gcc-11#exception_specification_changes # noqa
+        
+            @type: list of :class:`declaration_t`
+        """
         return self._exceptions
 
     @exceptions.setter
     def exceptions(self, exceptions):
+        """
+        Useless with c++17 and above as dynamich exceptions
+        are not allowed anymore:
+        https://developers.redhat.com/articles/2021/08/06/porting-your-code-c17-gcc-11#exception_specification_changes # noqa
+        """
         self._exceptions = exceptions
 
     @property

--- a/tests/data/declarations_calldef.hpp
+++ b/tests/data/declarations_calldef.hpp
@@ -22,8 +22,6 @@ int return_default_args( int arg=1, bool flag=false );
 
 extern void static_call();
 
-void calldef_with_throw() throw( some_exception_t, other_exception_t );
-
 struct calldefs_t{
     calldefs_t();
 

--- a/tests/data/test_dynamic_exception.hpp
+++ b/tests/data/test_dynamic_exception.hpp
@@ -1,0 +1,17 @@
+// Copyright 2014-2017 Insight Software Consortium.
+// Copyright 2004-2009 Roman Yakovenko.
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+
+
+namespace declarations {
+    namespace calldef {
+
+        class some_exception_t{};
+
+        class other_exception_t{};
+
+        void calldef_with_throw() throw( some_exception_t, other_exception_t );
+
+    }
+}

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -171,14 +171,6 @@ def test_calldef_free_functions(global_ns, helpers):
     )
     helpers._test_calldef_exceptions(global_ns, return_default_args, [])
 
-    calldef_with_throw = ns.free_function("calldef_with_throw")
-    assert calldef_with_throw is not None
-    helpers._test_calldef_exceptions(
-        global_ns, calldef_with_throw,
-        ["some_exception_t", "other_exception_t"]
-    )
-    # from now there is no need to check exception specification
-
 
 @pytest.mark.parametrize(
     "global_ns",

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -143,28 +143,6 @@ def test_calldefs(global_ns):
         for dependency in dependencies_new]
     assert used_types == ['int', 'int', 'bool']
 
-    some_exception = ns.class_('some_exception_t')
-    other_exception = ns.class_('other_exception_t')
-    calldef_with_throw = ns.calldef('calldef_with_throw')
-
-    # Legacy way of fetching dependencies. Is still valid but deprecated
-    warnings.simplefilter("ignore", Warning)
-    dependencies_old = calldef_with_throw.i_depend_on_them()
-    warnings.simplefilter("error", Warning)
-    assert len(dependencies_old) == 3
-    dependencies_old = [
-        dependency for dependency in dependencies_old if
-        dependency.depend_on_it in (some_exception, other_exception)]
-    assert len(dependencies_old) == 2
-
-    dependencies_new = declarations.get_dependencies_from_decl(
-        calldef_with_throw)
-    assert len(dependencies_new) == 3
-    dependencies_new = [
-        dependency for dependency in dependencies_new if
-        dependency.depend_on_it in (some_exception, other_exception)]
-    assert len(dependencies_new) == 2
-
 
 def test_coverage(global_ns):
     declarations.get_dependencies_from_decl(global_ns)

--- a/tests/test_dynamic_exception.py
+++ b/tests/test_dynamic_exception.py
@@ -1,0 +1,63 @@
+# Copyright 2014-2017 Insight Software Consortium.
+# Copyright 2004-2009 Roman Yakovenko.
+# Distributed under the Boost Software License, Version 1.0.
+# See http://www.boost.org/LICENSE_1_0.txt
+
+import pytest
+
+import warnings
+
+from . import autoconfig
+
+from pygccxml import parser
+from pygccxml import declarations
+
+
+TEST_FILES = [
+    "test_dynamic_exception.hpp",
+]
+
+
+@pytest.fixture
+def global_ns():
+    COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
+    config = autoconfig.cxx_parsers_cfg.config.clone()
+    # This test does not work with c++17 and above
+    # See https://developers.redhat.com/articles/2021/08/06/porting-your-code-c17-gcc-11#exception_specification_changes # noqa
+    # This test is thus excpected to use -std=c++14 forever
+    config.cflags = "-std=c++14"
+    decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
+    global_ns = declarations.get_global_namespace(decls)
+    global_ns.init_optimizer()
+    return global_ns
+
+
+def test_calldef_with_throw(global_ns, helpers):
+    calldef_with_throw = global_ns.free_function("calldef_with_throw")
+    assert calldef_with_throw is not None
+    helpers._test_calldef_exceptions(
+        global_ns, calldef_with_throw,
+        ["some_exception_t", "other_exception_t"]
+    )
+
+    calldef_with_throw = global_ns.calldef('calldef_with_throw')
+    some_exception = global_ns.class_('some_exception_t')
+    other_exception = global_ns.class_('other_exception_t')
+
+    # Legacy way of fetching dependencies. Is still valid but deprecated
+    warnings.simplefilter("ignore", Warning)
+    dependencies_old = calldef_with_throw.i_depend_on_them()
+    warnings.simplefilter("error", Warning)
+    assert len(dependencies_old) == 3
+    dependencies_old = [
+        dependency for dependency in dependencies_old if
+        dependency.depend_on_it in (some_exception, other_exception)]
+    assert len(dependencies_old) == 2
+
+    dependencies_new = declarations.get_dependencies_from_decl(
+        calldef_with_throw)
+    assert len(dependencies_new) == 3
+    dependencies_new = [
+        dependency for dependency in dependencies_new if
+        dependency.depend_on_it in (some_exception, other_exception)]
+    assert len(dependencies_new) == 2

--- a/tests/test_type_as_exception_bug.py
+++ b/tests/test_type_as_exception_bug.py
@@ -20,6 +20,10 @@ TEST_FILES = [
 def global_ns():
     COMPILATION_MODE = parser.COMPILATION_MODE.ALL_AT_ONCE
     config = autoconfig.cxx_parsers_cfg.config.clone()
+    # This test does not work with c++17 and above
+    # See https://developers.redhat.com/articles/2021/08/06/porting-your-code-c17-gcc-11#exception_specification_changes # noqa
+    # This test is thus excpected to use -std=c++14 forever
+    config.cflags = "-std=c++14"
     decls = parser.parse(TEST_FILES, config, COMPILATION_MODE)
     global_ns = declarations.get_global_namespace(decls)
     return global_ns


### PR DESCRIPTION
Fix failures when testes with c++17 and above
See https://github.com/CastXML/pygccxml/pull/227#issuecomment-2640919610

https://developers.redhat.com/articles/2021/08/06/porting-your-code-c17-gcc-11#exception_specification_changes From what I read here, there is no way to add exception specifications anymore (unless you use noexcept).