### PR TITLE
ARM test && CASTXML 0.6.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,14 +7,15 @@ on:
 
 jobs:
   tests:
-    name: ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.version }}-python-${{ matrix.python-version }}-${{ matrix.castxml-epic }}
+    name: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.compiler }}-${{ matrix.version }}-python-${{ matrix.python-version }}-${{ matrix.castxml-epic }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            arch: x86_64
             compiler: gcc
             version: "9"
             python-version: "3.9"
@@ -22,7 +23,8 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            arch: x86_64
             compiler: gcc
             version: "9"
             python-version: "3.10"
@@ -30,7 +32,8 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            arch: x86_64
             compiler: gcc
             version: "9"
             python-version: "3.11"
@@ -38,7 +41,8 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            arch: x86_64
             compiler: gcc
             version: "9"
             python-version: "3.12"
@@ -46,7 +50,8 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            arch: x86_64
             compiler: gcc
             version: "9"
             python-version: "3.13"
@@ -54,7 +59,8 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            arch: x86_64
             compiler: gcc
             version: "9"
             python-version: "3.13"
@@ -62,7 +68,71 @@ jobs:
             castxml-epic: 1
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            arch: x86_64
+            compiler: gcc
+            version: "9"
+            python-version: "3.13"
+            castxml: "castxml"
+            castxml-epic: 1
+            cppstd: "-std=c++11"
+            
+          - os: ubuntu-22.04-arm
+            arch: aarch64
+            compiler: gcc
+            version: "9"
+            python-version: "3.9"
+            castxml: "castxml"
+            castxml-epic: 0
+            cppstd: "-std=c++98"
+
+          - os: ubuntu-22.04-arm
+            arch: aarch64
+            compiler: gcc
+            version: "9"
+            python-version: "3.10"
+            castxml: "castxml"
+            castxml-epic: 0
+            cppstd: "-std=c++98"
+
+          - os: ubuntu-22.04-arm
+            arch: aarch64
+            compiler: gcc
+            version: "9"
+            python-version: "3.11"
+            castxml: "castxml"
+            castxml-epic: 0
+            cppstd: "-std=c++98"
+
+          - os: ubuntu-22.04-arm
+            arch: aarch64
+            compiler: gcc
+            version: "9"
+            python-version: "3.12"
+            castxml: "castxml"
+            castxml-epic: 0
+            cppstd: "-std=c++98"
+
+          - os: ubuntu-22.04-arm
+            arch: aarch64
+            compiler: gcc
+            version: "9"
+            python-version: "3.13"
+            castxml: "castxml"
+            castxml-epic: 0
+            cppstd: "-std=c++98"
+
+          - os: ubuntu-22.04-arm
+            arch: aarch64
+            compiler: gcc
+            version: "9"
+            python-version: "3.13"
+            castxml: "castxml"
+            castxml-epic: 1
+            cppstd: "-std=c++98"
+
+          - os: ubuntu-22.04-arm
+            arch: aarch64
             compiler: gcc
             version: "9"
             python-version: "3.13"
@@ -70,7 +140,8 @@ jobs:
             castxml-epic: 1
             cppstd: "-std=c++11"
 
-          - os: macos-13
+          - os: macos-15
+            arch: arm64
             compiler: xcode
             version: "default"
             python-version: "3.13"
@@ -79,9 +150,9 @@ jobs:
             cppstd: "-std=c++98"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -91,14 +162,46 @@ jobs:
           pip install '.[test]'
       - name: Run pycodestyle
         run: pycodestyle . --exclude=docs
-      - name: Setup castxml for Linux
-        if: matrix.os == 'ubuntu-20.04' && matrix.castxml == 'castxml'
+
+      # ─── Setup CastXML for Linux x86_64 ──────────────────────────────
+      - name: Setup CastXML for Linux x86_64 (Ubuntu 22.04)
+        if: matrix.os == 'ubuntu-22.04' && matrix.arch == 'x86_64'
         run: |
-          wget -q -O - https://data.kitware.com/api/v1/file/hashsum/sha512/bdbb67a10c5f8d1b738cd19cb074f409d4803e8077cb8c1072ef4eaf738fa871a73643f9c8282d58cae28d188df842c82ad6620b6d590b0396a0172a27438dce/download | tar zxf - -C ~/
-      - name: Setup castxml for Mac
-        if: matrix.os == 'macos-13'
+          wget -q -O ~/castxml-ubuntu-22.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz
+          tar -xzf ~/castxml-ubuntu-22.04-x86_64.tar.gz -C ~/
+          chmod +x ~/castxml/bin/castxml
+      - name: Setup CastXML for Linux x86_64 (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
         run: |
-          wget -q -O - https://data.kitware.com/api/v1/file/hashsum/sha512/5d937e938f7b882a3a3e7941e68f8312d0898aaf2082e00003dd362b1ba70b98b0a08706a1be28e71652a6a0f1e66f89768b5eaa20e5a100592d5b3deefec3f0/download | tar zxf - -C ~/
+          wget -q -O ~/castxml-ubuntu-24.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-x86_64.tar.gz
+          tar -xzf ~/castxml-ubuntu-24.04-x86_64.tar.gz -C ~/
+          chmod +x ~/castxml/bin/castxml
+      # ─── Setup CastXML for Linux ARM64 ──────────────────────────────
+      - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
+        if: matrix.os == 'ubuntu-22.04-arm' && matrix.arch == 'aarch64'
+        run: |
+          wget -q -O ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-arm-aarch64.tar.gz
+          tar -xzf ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz -C ~/
+          chmod +x ~/castxml/bin/castxml
+      - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04-arm' && matrix.arch == 'aarch64'
+        run: |
+          wget -q -O ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-arm-aarch64.tar.gz
+          tar -xzf ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz -C ~/
+          chmod +x ~/castxml/bin/castxml
+      # ─── Setup CastXML for macOS ─────────────────────────────────────
+      - name: Setup CastXML for macOS (x86_64)
+        if: matrix.os == 'macos-15' && matrix.arch == 'x86_64'
+        run: |
+          wget -q -O ~/castxml-castxml-macos-15-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-x86_64.tar.gz
+          tar -xzf ~/castxml-macos-15-x86_64.tar.gz -C ~/
+          chmod +x ~/castxml/bin/castxml
+      - name: Setup CastXML for macOS (ARM)
+        if: matrix.os == 'macos-15' && matrix.arch == 'arm64'
+        run: |
+          wget -q -O ~/castxml-macos-15-arm64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-arm64.tar.gz
+          tar -xzf ~/castxml-macos-15-arm64.tar.gz -C ~/
+          chmod +x ~/castxml/bin/castxml
       - name: Run tests
         run: |
           export PATH=~/castxml/bin:$PATH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
             python-version: "3.9"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -30,7 +30,7 @@ jobs:
             python-version: "3.10"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -39,7 +39,7 @@ jobs:
             python-version: "3.11"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -48,7 +48,7 @@ jobs:
             python-version: "3.12"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -57,7 +57,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -66,7 +66,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -84,7 +84,7 @@ jobs:
             python-version: "3.9"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -93,7 +93,7 @@ jobs:
             python-version: "3.10"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -102,7 +102,7 @@ jobs:
             python-version: "3.11"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -111,7 +111,7 @@ jobs:
             python-version: "3.12"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -120,7 +120,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -129,7 +129,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -147,7 +147,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++17"
+            cppstd: "-std=c++11"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.9"
             castxml: "castxml"
             castxml-epic: 0
@@ -26,7 +26,7 @@ jobs:
           - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.10"
             castxml: "castxml"
             castxml-epic: 0
@@ -35,7 +35,7 @@ jobs:
           - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.11"
             castxml: "castxml"
             castxml-epic: 0
@@ -44,7 +44,7 @@ jobs:
           - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.12"
             castxml: "castxml"
             castxml-epic: 0
@@ -53,7 +53,7 @@ jobs:
           - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
@@ -62,7 +62,7 @@ jobs:
           - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
@@ -71,7 +71,7 @@ jobs:
           - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
@@ -80,7 +80,7 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.9"
             castxml: "castxml"
             castxml-epic: 0
@@ -89,7 +89,7 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.10"
             castxml: "castxml"
             castxml-epic: 0
@@ -98,7 +98,7 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.11"
             castxml: "castxml"
             castxml-epic: 0
@@ -107,7 +107,7 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.12"
             castxml: "castxml"
             castxml-epic: 0
@@ -116,7 +116,7 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
@@ -125,7 +125,7 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
@@ -134,7 +134,7 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
-            version: "9"
+            version: "14"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
             version: "9"
@@ -23,7 +23,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
             version: "9"
@@ -32,7 +32,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
             version: "9"
@@ -41,7 +41,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
             version: "9"
@@ -50,7 +50,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
             version: "9"
@@ -59,7 +59,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
             version: "9"
@@ -68,7 +68,7 @@ jobs:
             castxml-epic: 1
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             arch: x86_64
             compiler: gcc
             version: "9"
@@ -77,7 +77,7 @@ jobs:
             castxml-epic: 1
             cppstd: "-std=c++11"
             
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
             version: "9"
@@ -86,7 +86,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
             version: "9"
@@ -95,7 +95,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
             version: "9"
@@ -104,7 +104,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
             version: "9"
@@ -113,7 +113,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
             version: "9"
@@ -122,7 +122,7 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
             version: "9"
@@ -131,7 +131,7 @@ jobs:
             castxml-epic: 1
             cppstd: "-std=c++98"
 
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             arch: aarch64
             compiler: gcc
             version: "9"
@@ -164,11 +164,11 @@ jobs:
         run: pycodestyle . --exclude=docs
 
       # ─── Setup CastXML for Linux x86_64 ──────────────────────────────
-      - name: Setup CastXML for Linux x86_64 (Ubuntu 22.04)
-        if: matrix.os == 'ubuntu-22.04' && matrix.arch == 'x86_64'
+      - name: Setup CastXML for Linux x86_64 (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
         run: |
-          wget -q -O ~/castxml-ubuntu-22.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz
-          tar -xzf ~/castxml-ubuntu-22.04-x86_64.tar.gz -C ~/
+          wget -q -O ~/castxml-ubuntu-24.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-x86_64.tar.gz
+          tar -xzf ~/castxml-ubuntu-24.04-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
       - name: Setup CastXML for Linux x86_64 (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
@@ -183,11 +183,11 @@ jobs:
           wget -q -O ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-arm-aarch64.tar.gz
           tar -xzf ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
-      - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
-        if: matrix.os == 'ubuntu-24.04-arm' && matrix.arch == 'aarch64'
+      - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
+        if: matrix.os == 'ubuntu-22.04-arm' && matrix.arch == 'aarch64'
         run: |
-          wget -q -O ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-arm-aarch64.tar.gz
-          tar -xzf ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz -C ~/
+          wget -q -O ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-arm-aarch64.tar.gz
+          tar -xzf ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
       # ─── Setup CastXML for macOS ─────────────────────────────────────
       - name: Setup CastXML for macOS (x86_64)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,17 +171,17 @@ jobs:
           tar -xzf ~/castxml-ubuntu-24.04-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
       - name: Setup CastXML for Linux x86_64 (Ubuntu 24.04)
-        if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
+        if: matrix.os == 'ubuntu-22.04' && matrix.arch == 'x86_64'
         run: |
-          wget -q -O ~/castxml-ubuntu-24.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-x86_64.tar.gz
-          tar -xzf ~/castxml-ubuntu-24.04-x86_64.tar.gz -C ~/
+          wget -q -O ~/castxml-ubuntu-22.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz
+          tar -xzf ~/castxml-ubuntu-22.04-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
       # ─── Setup CastXML for Linux ARM64 ──────────────────────────────
-      - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
-        if: matrix.os == 'ubuntu-22.04-arm' && matrix.arch == 'aarch64'
+      - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04-arm' && matrix.arch == 'aarch64'
         run: |
-          wget -q -O ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-arm-aarch64.tar.gz
-          tar -xzf ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz -C ~/
+          wget -q -O ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-arm-aarch64.tar.gz
+          tar -xzf ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
       - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04-arm' && matrix.arch == 'aarch64'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
         include:
           - os: ubuntu-24.04
             arch: x86_64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.9"
             castxml: "castxml"
             castxml-epic: 0
@@ -25,8 +25,8 @@ jobs:
 
           - os: ubuntu-24.04
             arch: x86_64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.10"
             castxml: "castxml"
             castxml-epic: 0
@@ -34,8 +34,8 @@ jobs:
 
           - os: ubuntu-24.04
             arch: x86_64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.11"
             castxml: "castxml"
             castxml-epic: 0
@@ -43,8 +43,8 @@ jobs:
 
           - os: ubuntu-24.04
             arch: x86_64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.12"
             castxml: "castxml"
             castxml-epic: 0
@@ -52,8 +52,8 @@ jobs:
 
           - os: ubuntu-24.04
             arch: x86_64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
@@ -61,8 +61,8 @@ jobs:
 
           - os: ubuntu-24.04
             arch: x86_64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
@@ -70,8 +70,8 @@ jobs:
 
           - os: ubuntu-24.04
             arch: x86_64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
@@ -79,8 +79,8 @@ jobs:
             
           - os: ubuntu-24.04-arm
             arch: aarch64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.9"
             castxml: "castxml"
             castxml-epic: 0
@@ -88,8 +88,8 @@ jobs:
 
           - os: ubuntu-24.04-arm
             arch: aarch64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.10"
             castxml: "castxml"
             castxml-epic: 0
@@ -97,8 +97,8 @@ jobs:
 
           - os: ubuntu-24.04-arm
             arch: aarch64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.11"
             castxml: "castxml"
             castxml-epic: 0
@@ -106,8 +106,8 @@ jobs:
 
           - os: ubuntu-24.04-arm
             arch: aarch64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.12"
             castxml: "castxml"
             castxml-epic: 0
@@ -115,8 +115,8 @@ jobs:
 
           - os: ubuntu-24.04-arm
             arch: aarch64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
@@ -124,8 +124,8 @@ jobs:
 
           - os: ubuntu-24.04-arm
             arch: aarch64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
@@ -133,8 +133,8 @@ jobs:
 
           - os: ubuntu-24.04-arm
             arch: aarch64
-            compiler: gcc
-            version: "14"
+            compiler: clang
+            version: "18"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
@@ -142,8 +142,8 @@ jobs:
 
           - os: macos-15
             arch: arm64
-            compiler: xcode
-            version: "default"
+            compiler: clang
+            version: "18"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
@@ -151,17 +151,36 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
+
       - name: Install Python lib and test libs
         run: |
           pip install '.[test]'
+
       - name: Run pycodestyle
         run: pycodestyle . --exclude=docs
+
+      # Install LLVM Clang 18 on Ubuntu runners
+      - name: Install LLVM Clang 18 on Ubuntu
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-18 lldb-18 libclang-18-dev
+
+      # Install LLVM Clang 18 on macOS runners
+      - name: Install LLVM Clang 18 on macOS
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew update
+          brew install llvm@18
+          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
 
       # ─── Setup CastXML for Linux x86_64 ──────────────────────────────
       - name: Setup CastXML for Linux x86_64 (Ubuntu 24.04)
@@ -170,12 +189,14 @@ jobs:
           wget -q -O ~/castxml-ubuntu-24.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-x86_64.tar.gz
           tar -xzf ~/castxml-ubuntu-24.04-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
-      - name: Setup CastXML for Linux x86_64 (Ubuntu 24.04)
+
+      - name: Setup CastXML for Linux x86_64 (Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04' && matrix.arch == 'x86_64'
         run: |
           wget -q -O ~/castxml-ubuntu-22.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz
           tar -xzf ~/castxml-ubuntu-22.04-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
+
       # ─── Setup CastXML for Linux ARM64 ──────────────────────────────
       - name: Setup CastXML for Linux ARM64 (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04-arm' && matrix.arch == 'aarch64'
@@ -183,25 +204,29 @@ jobs:
           wget -q -O ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-arm-aarch64.tar.gz
           tar -xzf ~/castxml-ubuntu-24.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
+
       - name: Setup CastXML for Linux ARM64 (Ubuntu 22.04)
         if: matrix.os == 'ubuntu-22.04-arm' && matrix.arch == 'aarch64'
         run: |
           wget -q -O ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-arm-aarch64.tar.gz
           tar -xzf ~/castxml-ubuntu-22.04-arm-aarch64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
+
       # ─── Setup CastXML for macOS ─────────────────────────────────────
       - name: Setup CastXML for macOS (x86_64)
         if: matrix.os == 'macos-15' && matrix.arch == 'x86_64'
         run: |
           wget -q -O ~/castxml-castxml-macos-15-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-x86_64.tar.gz
-          tar -xzf ~/castxml-macos-15-x86_64.tar.gz -C ~/
+          tar -xzf ~/castxml-castxml-macos-15-x86_64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
+
       - name: Setup CastXML for macOS (ARM)
         if: matrix.os == 'macos-15' && matrix.arch == 'arm64'
         run: |
           wget -q -O ~/castxml-macos-15-arm64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-macos-15-arm64.tar.gz
           tar -xzf ~/castxml-macos-15-arm64.tar.gz -C ~/
           chmod +x ~/castxml/bin/castxml
+
       - name: Run tests
         run: |
           export PATH=~/castxml/bin:$PATH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
             python-version: "3.9"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -30,7 +30,7 @@ jobs:
             python-version: "3.10"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -39,7 +39,7 @@ jobs:
             python-version: "3.11"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -48,7 +48,7 @@ jobs:
             python-version: "3.12"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -57,7 +57,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -66,7 +66,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04
             arch: x86_64
@@ -84,7 +84,7 @@ jobs:
             python-version: "3.9"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -93,7 +93,7 @@ jobs:
             python-version: "3.10"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -102,7 +102,7 @@ jobs:
             python-version: "3.11"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -111,7 +111,7 @@ jobs:
             python-version: "3.12"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -120,7 +120,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -129,7 +129,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
           - os: ubuntu-24.04-arm
             arch: aarch64
@@ -138,7 +138,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
-            cppstd: "-std=c++11"
+            cppstd: "-std=c++20"
 
           - os: macos-15
             arch: arm64
@@ -147,7 +147,7 @@ jobs:
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
-            cppstd: "-std=c++98"
+            cppstd: "-std=c++17"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration to support new operating system versions and architectures, as well as updates to the setup steps for various tools.

### Workflow Configuration Updates:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL10-R155): Updated the matrix to include `arch` and added support for `ubuntu-24.04` and `ubuntu-24.04-arm` with various Python versions and C++ standards. Also, added support for `macos-15` with `arm64` architecture.

### Tool Setup Updates:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL94-R204): Updated the CastXML setup steps to support the new OS versions and architectures, including specific setup commands for `ubuntu-24.04`, `ubuntu-22.04`, and `macos-15` for both `x86_64` and `arm64` architectures.