### PR TITLE
tests: move to ubuntu 22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,62 +14,65 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          # UBUNTU 24.04 - CASTXML EPIC 0
+          - os: ubuntu-22.04
             compiler: gcc
-            version: "9"
+            version: "11"
             python-version: "3.9"
             castxml: "castxml"
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
-            version: "9"
+            version: "11"
             python-version: "3.10"
             castxml: "castxml"
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
-            version: "9"
+            version: "11"
             python-version: "3.11"
             castxml: "castxml"
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
-            version: "9"
+            version: "11"
             python-version: "3.12"
             castxml: "castxml"
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
-            version: "9"
+            version: "11"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 0
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          # UBUNTU 24.04 - CASTXML EPIC 1
+          - os: ubuntu-22.04
             compiler: gcc
-            version: "9"
+            version: "11"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
             cppstd: "-std=c++98"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
-            version: "9"
+            version: "11"
             python-version: "3.13"
             castxml: "castxml"
             castxml-epic: 1
             cppstd: "-std=c++11"
 
+          # MACOS
           - os: macos-13
             compiler: xcode
             version: "default"
@@ -92,7 +95,7 @@ jobs:
       - name: Run pycodestyle
         run: pycodestyle . --exclude=docs
       - name: Setup castxml for Linux
-        if: matrix.os == 'ubuntu-20.04' && matrix.castxml == 'castxml'
+        if: matrix.os == 'ubuntu-22.04' && matrix.castxml == 'castxml'
         run: |
           wget -q -O - https://data.kitware.com/api/v1/file/hashsum/sha512/bdbb67a10c5f8d1b738cd19cb074f409d4803e8077cb8c1072ef4eaf738fa871a73643f9c8282d58cae28d188df842c82ad6620b6d590b0396a0172a27438dce/download | tar zxf - -C ~/
       - name: Setup castxml for Mac


### PR DESCRIPTION
Add/keep one test on ubuntu 20.04 as this is still supported