### PR TITLE
PART 3: Windows Runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,14 @@ jobs:
             castxml-epic: 0
             cppstd: "-std=c++98"
 
+          - os: windows-2025
+            compiler: msvc
+            version: "default"
+            python-version: "3.13"
+            castxml: "castxml"
+            castxml-epic: 0
+            cppstd: "-std=c++98"
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,7 @@ jobs:
         run: |
           wget -q -O - https://data.kitware.com/api/v1/file/hashsum/sha512/5d937e938f7b882a3a3e7941e68f8312d0898aaf2082e00003dd362b1ba70b98b0a08706a1be28e71652a6a0f1e66f89768b5eaa20e5a100592d5b3deefec3f0/download | tar zxf - -C ~/
       - name: Run tests
+        shel: bash
         run: |
           export PATH=~/castxml/bin:$PATH
           pytest tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           wget -q -O - https://data.kitware.com/api/v1/file/hashsum/sha512/5d937e938f7b882a3a3e7941e68f8312d0898aaf2082e00003dd362b1ba70b98b0a08706a1be28e71652a6a0f1e66f89768b5eaa20e5a100592d5b3deefec3f0/download | tar zxf - -C ~/
       - name: Run tests
-        shel: bash
+        shell: bash
         run: |
           export PATH=~/castxml/bin:$PATH
           pytest tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,7 @@ jobs:
             cppstd: "-std=c++98"
 
           - os: windows-2025
+            aarch: amd64
             compiler: msvc
             version: "default"
             python-version: "3.13"


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow configuration file `.github/workflows/tests.yml` to add a new job for testing on a different operating system and architecture.

* Added a new job configuration for `os: windows-2025`, `aarch: amd64`, `compiler: msvc`, `version: "default"`, `python-version: "3.13"`, `castxml: "castxml"`, `castxml-epic: 0`, and `cppstd: "-std=c++98"`.