### PR TITLE
PART 1: castxml 0.6.11 x86_64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
         include:
           # UBUNTU 22.04 - CASTXML EPIC 0
           - os: ubuntu-22.04
+            arch: x86_64
             compiler: clang++
             clang-version: 13
             python-version: "3.13"
@@ -23,6 +24,7 @@ jobs:
             cppstd: "-std=c++98"
           
           - os: ubuntu-22.04
+            arch: x86_64
             compiler: clang++
             clang-version: 14
             python-version: "3.13"
@@ -30,6 +32,7 @@ jobs:
             cppstd: "-std=c++98"
 
           - os: ubuntu-22.04
+            arch: x86_64
             compiler: clang++
             clang-version: 15
             python-version: "3.13"
@@ -37,6 +40,7 @@ jobs:
             cppstd: "-std=c++98"
 
           - os: ubuntu-22.04
+            arch: x86_64
             compiler: clang++
             clang-version: 15
             python-version: "3.13"
@@ -45,6 +49,7 @@ jobs:
   
           # UBUNTU 24.04 - CASTXML EPIC 0
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.9"
@@ -52,6 +57,7 @@ jobs:
             cppstd: "-std=c++98"
 
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.10"
@@ -59,6 +65,7 @@ jobs:
             cppstd: "-std=c++98"
 
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.11"
@@ -66,6 +73,7 @@ jobs:
             cppstd: "-std=c++98"
 
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.12"
@@ -73,6 +81,7 @@ jobs:
             cppstd: "-std=c++98"
 
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.13"
@@ -81,6 +90,7 @@ jobs:
 
           # UBUNTU 24.04 - CASTXML EPIC 0 - c++XX
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.13"
@@ -88,6 +98,7 @@ jobs:
             cppstd: "-std=c++11"
 
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.13"
@@ -95,6 +106,7 @@ jobs:
             cppstd: "-std=c++14"
 
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.13"
@@ -103,6 +115,7 @@ jobs:
 
           # UBUNTU 24.04 - CASTXML EPIC 1
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.13"
@@ -110,6 +123,7 @@ jobs:
             cppstd: "-std=c++98"
 
           - os: ubuntu-24.04
+            arch: x86_64
             compiler: clang++
             clang-version: 16
             python-version: "3.13"
@@ -152,14 +166,27 @@ jobs:
           echo "compiler_path=/usr/bin/${{ matrix.compiler }}-${{ matrix.clang-version }}" >> tests/xml_generator.cfg
           echo "ccflags=${{ matrix.cppstd }}" >> tests/xml_generator.cfg
 
-      - name: Setup castxml for Linux
-        if: contains(matrix.os, 'ubuntu')
+      # ─── Setup CastXML for Linux x86_64 ──────────────────────────────
+      - name: Setup CastXML for Linux x86_64 (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
         run: |
-          wget -q -O - https://data.kitware.com/api/v1/file/hashsum/sha512/bdbb67a10c5f8d1b738cd19cb074f409d4803e8077cb8c1072ef4eaf738fa871a73643f9c8282d58cae28d188df842c82ad6620b6d590b0396a0172a27438dce/download | tar zxf - -C ~/
+          wget -q -O ~/castxml-ubuntu-24.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-24.04-x86_64.tar.gz
+          tar -xzf ~/castxml-ubuntu-24.04-x86_64.tar.gz -C ~/
+          chmod +x ~/castxml/bin/castxml
+
+      - name: Setup CastXML for Linux x86_64 (Ubuntu 22.04)
+        if: matrix.os == 'ubuntu-22.04' && matrix.arch == 'x86_64'
+        run: |
+          wget -q -O ~/castxml-ubuntu-22.04-x86_64.tar.gz https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz
+          tar -xzf ~/castxml-ubuntu-22.04-x86_64.tar.gz -C ~/
+          chmod +x ~/castxml/bin/castxml
+
+      # ─── Setup CastXML for MacOS ──────────────────────────────
       - name: Setup castxml for Mac
         if: contains(matrix.os, 'macos')
         run: |
           wget -q -O - https://data.kitware.com/api/v1/file/hashsum/sha512/5d937e938f7b882a3a3e7941e68f8312d0898aaf2082e00003dd362b1ba70b98b0a08706a1be28e71652a6a0f1e66f89768b5eaa20e5a100592d5b3deefec3f0/download | tar zxf - -C ~/
+
       - name: Run tests
         run: |
           export PATH=~/castxml/bin:$PATH

--- a/src/pygccxml/declarations/container_traits.py
+++ b/src/pygccxml/declarations/container_traits.py
@@ -38,7 +38,8 @@ class defaults_eraser(object):
     def normalize(self, type_str):
         return type_str.replace(' ', '')
 
-    def replace_basic_string(self, cls_name):
+    @staticmethod
+    def replace_basic_string(cls_name):
         strings = {
             "std::string": string_equivalences,
             "std::wstring": wstring_equivalences
@@ -48,7 +49,6 @@ class defaults_eraser(object):
         for short_name, long_names in strings.items():
             for lname in long_names:
                 new_name = new_name.replace(lname, short_name)
-
         return new_name
 
     def decorated_call_prefix(self, cls_name, text, doit):
@@ -99,7 +99,6 @@ class defaults_eraser(object):
         return self.no_end_const(cls_name)
 
     def erase_allocator(self, cls_name, default_allocator='std::allocator'):
-        cls_name = self.replace_basic_string(cls_name)
         c_name, c_args = templates.split(cls_name)
         if len(c_args) != 2:
             return
@@ -116,7 +115,6 @@ class defaults_eraser(object):
                 c_name, [self.erase_recursive(value_type)])
 
     def erase_container(self, cls_name, default_container_name='std::deque'):
-        cls_name = self.replace_basic_string(cls_name)
         c_name, c_args = templates.split(cls_name)
         if len(c_args) != 2:
             return
@@ -132,7 +130,6 @@ class defaults_eraser(object):
             cls_name,
             default_container_name='std::vector',
             default_compare='std::less'):
-        cls_name = self.replace_basic_string(cls_name)
         c_name, c_args = templates.split(cls_name)
         if len(c_args) != 3:
             return
@@ -152,7 +149,6 @@ class defaults_eraser(object):
             cls_name,
             default_compare='std::less',
             default_allocator='std::allocator'):
-        cls_name = self.replace_basic_string(cls_name)
         c_name, c_args = templates.split(cls_name)
         if len(c_args) != 3:
             return
@@ -175,7 +171,6 @@ class defaults_eraser(object):
             cls_name,
             default_compare='std::less',
             default_allocator='std::allocator'):
-        cls_name = self.replace_basic_string(cls_name)
         c_name, c_args = templates.split(cls_name)
         if len(c_args) != 4:
             return
@@ -205,7 +200,6 @@ class defaults_eraser(object):
                      self.erase_recursive(mapped_type)])
 
     def erase_hash_allocator(self, cls_name):
-        cls_name = self.replace_basic_string(cls_name)
         c_name, c_args = templates.split(cls_name)
         if len(c_args) < 3:
             return
@@ -243,7 +237,6 @@ class defaults_eraser(object):
                     c_name, [self.erase_recursive(value_type)])
 
     def erase_hashmap_compare_allocator(self, cls_name):
-        cls_name = self.replace_basic_string(cls_name)
         c_name, c_args = templates.split(cls_name)
 
         if self.unordered_maps_and_sets:
@@ -523,6 +516,7 @@ class container_traits_impl_t(object):
         name = type_or_string
         if not isinstance(type_or_string, str):
             name = self.class_declaration(type_or_string).name
+        name = defaults_eraser.replace_basic_string(name)
         if not self.remove_defaults_impl:
             return name
         no_defaults = self.remove_defaults_impl(name)


### PR DESCRIPTION
This pull request updates the `.github/workflows/tests.yml` file to include architecture specification and improve the setup process for CastXML on different operating systems. The most important changes include adding the `arch` field to the job matrix and splitting the CastXML setup steps based on the OS and architecture.

Updates to the job matrix:

* Added `arch: x86_64` to all job entries to specify the architecture for the build matrix. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR19-R43) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR52-R84) [[3]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR93-R109) [[4]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR118-R126)

Improvements to CastXML setup:

* Split the CastXML setup steps into separate sections for Ubuntu 22.04 and Ubuntu 24.04 based on the OS and architecture.
* Added specific URLs for downloading CastXML for Ubuntu 22.04 and Ubuntu 24.04.