### PR TITLE
ci: build releases in pypi

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,10 @@ on:
     branches:
       - main
       - develop
+  release:
+    types: [created]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   tests:
@@ -241,3 +244,32 @@ jobs:
         run: |
           export PATH=~/castxml/bin:$PATH
           pytest tests
+
+  build-release:
+    name: Build distribution 📦
+    if: (github.event_name == 'release' && github.event.action == 'created') || (github.event_name == 'workflow_dispatch')
+    needs: tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/


### PR DESCRIPTION
Based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ Testing only the build part for the time being, pypi upload will come in a second step